### PR TITLE
fix: typo in post login url - allow both versions

### DIFF
--- a/src/config/index.js
+++ b/src/config/index.js
@@ -6,11 +6,12 @@ const initialState = {
 
 const SESSION_PREFIX = 'pkce-verifier';
 
-const KINDE_SITE_URL = process.env.KINDE_SITE_URL || process.env.VERCEL_URL;
-const KINDE_POST_LOGIN_URL_REDIRECT_URL =
-  process.env.KINDE_POST_LOGIN_URL_REDIRECT_URL || process.env.VERCEL_URL;
+const KINDE_SITE_URL = process.env.KINDE_SITE_URL;
+const KINDE_POST_LOGIN_REDIRECT_URL =
+  process.env.KINDE_POST_LOGIN_REDIRECT_URL ||
+  process.env.KINDE_POST_LOGIN_URL_REDIRECT_URL;
 const KINDE_POST_LOGOUT_REDIRECT_URL =
-  process.env.KINDE_POST_LOGOUT_REDIRECT_URL || process.env.VERCEL_URL;
+  process.env.KINDE_POST_LOGOUT_REDIRECT_URL;
 
 const KINDE_ISSUER_URL = process.env.KINDE_ISSUER_URL;
 const KINDE_CLIENT_ID = process.env.KINDE_CLIENT_ID;
@@ -21,7 +22,7 @@ export const config = {
   initialState,
   SESSION_PREFIX,
   redirectURL: KINDE_SITE_URL,
-  postLoginURL: KINDE_POST_LOGIN_URL_REDIRECT_URL,
+  postLoginURL: KINDE_POST_LOGIN_REDIRECT_URL,
   issuerURL: KINDE_ISSUER_URL,
   clientID: KINDE_CLIENT_ID,
   clientSecret: KINDE_CLIENT_SECRET,


### PR DESCRIPTION
# Explain your changes

1. There was a typo in `KINDE_POST_LOGIN_URL_REDIRECT_URL` which had an extra `URL` updated the API of the SDK to allow both in the name of backwards compatability:

`KINDE_POST_LOGIN_URL_REDIRECT_URL`
or
`KINDE_POST_LOGIN_REDIRECT_URL`

2. Removed baked in vercel fallbacks

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/489e2ca9c3307c2b2e098a885e22f2239116394a/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/489e2ca9c3307c2b2e098a885e22f2239116394a/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/489e2ca9c3307c2b2e098a885e22f2239116394a/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
