### PR TITLE
Allow custom API path

### DIFF
--- a/src/components/CreateOrgLink.js
+++ b/src/components/CreateOrgLink.js
@@ -1,9 +1,11 @@
 import React from 'react';
 
+import {config} from '../config/index';
+
 export function CreateOrgLink({children, orgName, ...props}) {
   return (
     <a
-      href={`/api/auth/create_org${orgName ? `?org_name=${orgName}` : ''}`}
+      href={`${config.apiPath}/create_org${orgName ? `?org_name=${orgName}` : ''}`}
       {...props}
     >
       {children}

--- a/src/components/LoginLink.js
+++ b/src/components/LoginLink.js
@@ -1,9 +1,11 @@
 import React from 'react';
 
+import {config} from '../config/index';
+
 export function LoginLink({children, orgCode, ...props}) {
   return (
     <a
-      href={`/api/auth/login${orgCode ? `?org_code=${orgCode}` : ''}`}
+      href={`${config.apiPath}/login${orgCode ? `?org_code=${orgCode}` : ''}`}
       {...props}
     >
       {children}

--- a/src/components/LogoutLink.js
+++ b/src/components/LogoutLink.js
@@ -1,8 +1,10 @@
 import React from 'react';
 
+import {config} from '../config/index';
+
 export function LogoutLink({children, ...props}) {
   return (
-    <a href="/api/auth/logout" {...props}>
+    <a href={`${config.apiPath}/logout`} {...props}>
       {children}
     </a>
   );

--- a/src/components/RegisterLink.js
+++ b/src/components/RegisterLink.js
@@ -1,9 +1,11 @@
 import React from 'react';
 
+import {config} from '../config/index';
+
 export function RegisterLink({children, orgCode, ...props}) {
   return (
     <a
-      href={`/api/auth/register${orgCode ? `?org_code=${orgCode}` : ''}`}
+      href={`${config.apiPath}/register${orgCode ? `?org_code=${orgCode}` : ''}`}
       {...props}
     >
       {children}

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -7,6 +7,7 @@ const initialState = {
 const SESSION_PREFIX = 'pkce-verifier';
 
 const KINDE_SITE_URL = process.env.KINDE_SITE_URL;
+const KINDE_API_PATH = process.env.KINDE_API_PATH || '/api/auth';
 const KINDE_POST_LOGIN_REDIRECT_URL =
   process.env.KINDE_POST_LOGIN_REDIRECT_URL ||
   process.env.KINDE_POST_LOGIN_URL_REDIRECT_URL;
@@ -19,6 +20,7 @@ const KINDE_CLIENT_SECRET = process.env.KINDE_CLIENT_SECRET;
 const KINDE_AUDIENCE = process.env.KINDE_AUDIENCE;
 
 export const config = {
+  apiPath: KINDE_API_PATH,
   initialState,
   SESSION_PREFIX,
   redirectURL: KINDE_SITE_URL,
@@ -32,7 +34,7 @@ export const config = {
   scope: 'openid profile email offline',
   codeChallengeMethod: 'S256',
   redirectRoutes: {
-    callback: '/api/auth/kinde_callback'
+    callback: `${KINDE_API_PATH}/kinde_callback`
   },
   issuerRoutes: {
     logout: '/logout',

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -7,7 +7,7 @@ const initialState = {
 const SESSION_PREFIX = 'pkce-verifier';
 
 const KINDE_SITE_URL = process.env.KINDE_SITE_URL;
-const KINDE_API_PATH = process.env.KINDE_API_PATH || '/api/auth';
+const KINDE_AUTH_API_PATH = process.env.KINDE_AUTH_API_PATH || '/api/auth';
 const KINDE_POST_LOGIN_REDIRECT_URL =
   process.env.KINDE_POST_LOGIN_REDIRECT_URL ||
   process.env.KINDE_POST_LOGIN_URL_REDIRECT_URL;
@@ -20,7 +20,7 @@ const KINDE_CLIENT_SECRET = process.env.KINDE_CLIENT_SECRET;
 const KINDE_AUDIENCE = process.env.KINDE_AUDIENCE;
 
 export const config = {
-  apiPath: KINDE_API_PATH,
+  apiPath: KINDE_AUTH_API_PATH,
   initialState,
   SESSION_PREFIX,
   redirectURL: KINDE_SITE_URL,
@@ -34,7 +34,7 @@ export const config = {
   scope: 'openid profile email offline',
   codeChallengeMethod: 'S256',
   redirectRoutes: {
-    callback: `${KINDE_API_PATH}/kinde_callback`
+    callback: `${KINDE_AUTH_API_PATH}/kinde_callback`
   },
   issuerRoutes: {
     logout: '/logout',

--- a/src/frontend/AuthProvider.jsx
+++ b/src/frontend/AuthProvider.jsx
@@ -5,6 +5,7 @@ import React, {
   useCallback,
   useEffect
 } from 'react';
+
 import {config} from '../config/index';
 
 const flagDataTypeMap = {
@@ -75,7 +76,7 @@ export const KindeProvider = ({children}) => {
     getToken: () => null
   });
 
-  const setupUrl = '/api/auth/setup';
+  const setupUrl = `${config.apiPath}/setup`;
 
   // try and get the user (by fetching /api/auth/setup) -> this needs to do the OAuth stuff
   const checkSession = useCallback(async () => {


### PR DESCRIPTION
# Explain your changes

I have added the ability to support custom API paths using the ENV var `KINDE_API_PATH`. This is important as it helps migrating from another library e.g. NextAuth. Both libraries use the same route `/api/auth` which means you can't run them side by side when migrating between the two and makes migrations more complex and risky.

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
