### PR TITLE
post login redirect for app router

### DIFF
--- a/src/components/LoginLink.js
+++ b/src/components/LoginLink.js
@@ -4,8 +4,8 @@ import {config} from '../config/index';
 
 export function LoginLink({children, postLoginRedirectURL, orgCode, ...props}) {
   let params = new URLSearchParams();
-  orgCode && params.append('org_code', orgCode);
-  postLoginRedirectURL &&
+  if (orgCode !== null) params.append('org_code', orgCode);
+  if (postLoginRedirectURL !== null)
     params.append('post_login_redirect_url', postLoginRedirectURL);
   return (
     <a

--- a/src/components/LoginLink.js
+++ b/src/components/LoginLink.js
@@ -3,14 +3,10 @@ import React from 'react';
 import {config} from '../config/index';
 
 export function LoginLink({children, postLoginRedirectURL, orgCode, ...props}) {
-  const params = new URLSearchParams(
-    JSON.parse(
-      JSON.stringify({
-        org_code: orgCode,
-        post_login_redirect_url: postLoginRedirectURL
-      })
-    )
-  );
+  let params = new URLSearchParams();
+  orgCode && params.append('org_code', orgCode);
+  postLoginRedirectURL &&
+    params.append('post_login_redirect_url', postLoginRedirectURL);
   return (
     <a
       href={`${config.apiPath}/login${params ? `?${params.toString()}` : ''}`}

--- a/src/components/LoginLink.js
+++ b/src/components/LoginLink.js
@@ -2,10 +2,18 @@ import React from 'react';
 
 import {config} from '../config/index';
 
-export function LoginLink({children, orgCode, ...props}) {
+export function LoginLink({children, postLoginRedirectURL, orgCode, ...props}) {
+  const params = new URLSearchParams(
+    JSON.parse(
+      JSON.stringify({
+        org_code: orgCode,
+        post_login_redirect_url: postLoginRedirectURL
+      })
+    )
+  );
   return (
     <a
-      href={`${config.apiPath}/login${orgCode ? `?org_code=${orgCode}` : ''}`}
+      href={`${config.apiPath}/login${params ? `?${params.toString()}` : ''}`}
       {...props}
     >
       {children}

--- a/src/components/RegisterLink.js
+++ b/src/components/RegisterLink.js
@@ -8,15 +8,10 @@ export function RegisterLink({
   postLoginRedirectURL,
   ...props
 }) {
-  const params = new URLSearchParams(
-    JSON.parse(
-      JSON.stringify({
-        org_code: orgCode,
-        post_login_redirect_url: postLoginRedirectURL
-      })
-    )
-  );
-
+  let params = new URLSearchParams();
+  orgCode && params.append('org_code', orgCode);
+  postLoginRedirectURL &&
+    params.append('post_login_redirect_url', postLoginRedirectURL);
   return (
     <a
       href={`${config.apiPath}/register${

--- a/src/components/RegisterLink.js
+++ b/src/components/RegisterLink.js
@@ -2,10 +2,26 @@ import React from 'react';
 
 import {config} from '../config/index';
 
-export function RegisterLink({children, orgCode, ...props}) {
+export function RegisterLink({
+  children,
+  orgCode,
+  postLoginRedirectURL,
+  ...props
+}) {
+  const params = new URLSearchParams(
+    JSON.parse(
+      JSON.stringify({
+        org_code: orgCode,
+        post_login_redirect_url: postLoginRedirectURL
+      })
+    )
+  );
+
   return (
     <a
-      href={`${config.apiPath}/register${orgCode ? `?org_code=${orgCode}` : ''}`}
+      href={`${config.apiPath}/register${
+        params ? `?${params.toString()}` : ''
+      }`}
       {...props}
     >
       {children}

--- a/src/components/RegisterLink.js
+++ b/src/components/RegisterLink.js
@@ -9,8 +9,8 @@ export function RegisterLink({
   ...props
 }) {
   let params = new URLSearchParams();
-  orgCode && params.append('org_code', orgCode);
-  postLoginRedirectURL &&
+  if (orgCode !== null) params.append('org_code', orgCode);
+  if (postLoginRedirectURL !== null)
     params.append('post_login_redirect_url', postLoginRedirectURL);
   return (
     <a

--- a/src/handlers/appRouter/callback.js
+++ b/src/handlers/appRouter/callback.js
@@ -3,14 +3,27 @@ import {config} from '../../config/index';
 import {version} from '../../utils/version';
 import {cookies} from 'next/headers';
 import {redirect} from 'next/navigation';
+import {sanitizeRedirect} from '../../utils/sanitizeRedirect';
 
 export const callback = async (request) => {
   const code = request.nextUrl.searchParams.get('code');
   const state = request.nextUrl.searchParams.get('state');
 
   const cookieStore = cookies();
-  const code_verifier = cookieStore.get(`${config.SESSION_PREFIX}-${state}`);
-  if (code_verifier) {
+  const jsonCookieValue = cookieStore.get(`${config.SESSION_PREFIX}-${state}`);
+
+  let redirectUrl = config.postLoginRedirectURL || config.redirectURL;
+
+  if (jsonCookieValue) {
+    const {code_verifier, options} = JSON.parse(jsonCookieValue.value);
+
+    if (options?.post_login_redirect_url) {
+      redirectUrl = sanitizeRedirect({
+        baseUrl: new URL(config.redirectURL).origin,
+        url: options.post_login_redirect_url
+      });
+    }
+
     try {
       const response = await fetch(
         config.issuerURL + config.issuerRoutes.token,
@@ -24,17 +37,19 @@ export const callback = async (request) => {
             client_id: config.clientID,
             client_secret: config.clientSecret,
             code: code,
-            code_verifier: code_verifier.value,
+            code_verifier: code_verifier,
             grant_type: 'authorization_code',
             redirect_uri: `${config.redirectURL}${config.redirectRoutes.callback}`
           })
         }
       );
       const data = await response.json();
+      console.log('look here', data);
       const tokenHeader = jwt_decode(data.access_token, {header: true});
       const payload = jwt_decode(data.access_token);
+
       let isAudienceValid = true;
-      
+
       if (config.audience)
         isAudienceValid = payload.aud && payload.aud.includes(config.audience);
 
@@ -59,9 +74,6 @@ export const callback = async (request) => {
     } catch (err) {
       console.error({err});
     }
-    const redirectUrl = config.postLoginRedirectURL
-      ? config.postLoginRedirectURL
-      : config.redirectURL;
     redirect(redirectUrl);
   } else {
     const logoutURL = new URL(config.issuerURL + config.issuerRoutes.logout);

--- a/src/handlers/appRouter/handleAuth.js
+++ b/src/handlers/appRouter/handleAuth.js
@@ -1,9 +1,8 @@
-import {redirect} from 'next/navigation';
+import {callback} from './callback';
+import {createOrg} from './createOrg';
 import {login} from './login';
 import {logout} from './logout';
 import {register} from './register';
-import {callback} from './callback';
-import {createOrg} from './createOrg';
 
 const routeMap = {
   create_org: createOrg,

--- a/src/handlers/appRouter/login.js
+++ b/src/handlers/appRouter/login.js
@@ -1,10 +1,12 @@
-import {generateAuthUrl} from '../../utils/generateAuthUrl';
 import {redirect} from 'next/navigation';
 import {prepareForRedirect} from '../../utils/appRouter/prepareForRedirect';
 
 export const login = async (request) => {
   const org_code = request.nextUrl.searchParams.get('org_code');
-  const options = {org_code};
+  const post_login_redirect_url = request.nextUrl.searchParams.get(
+    'post_login_redirect_url'
+  );
+  const options = {org_code, post_login_redirect_url};
   const authUrl = prepareForRedirect(options);
 
   redirect(authUrl);

--- a/src/handlers/appRouter/register.js
+++ b/src/handlers/appRouter/register.js
@@ -3,8 +3,11 @@ import {redirect} from 'next/navigation';
 
 export const register = async (request) => {
   const org_code = request.nextUrl.searchParams.get('org_code');
+  const post_login_redirect_url = request.nextUrl.searchParams.get(
+    'post_login_redirect_url'
+  );
 
-  const options = {org_code};
+  const options = {org_code, post_login_redirect_url};
 
   const authUrl = prepareForRedirect(options, 'register');
 

--- a/src/utils/appRouter/prepareForRedirect.js
+++ b/src/utils/appRouter/prepareForRedirect.js
@@ -4,7 +4,7 @@ import {generateAuthUrl} from '../generateAuthUrl';
 
 export const prepareForRedirect = (options, type = 'login') => {
   const {code_challenge, code_verifier, state} = setupChallenge();
-  setVerifierCookie(state, code_verifier);
+  setVerifierCookie(state, code_verifier, options);
   options.state = state;
   options.code_challenge = code_challenge;
 

--- a/src/utils/appRouter/setVerifierCookie.js
+++ b/src/utils/appRouter/setVerifierCookie.js
@@ -1,10 +1,10 @@
 import {config} from '../../config/index';
 import {cookies} from 'next/headers';
 
-export const setVerifierCookie = (state, code_verifier) => {
+export const setVerifierCookie = (state, code_verifier, options) => {
   cookies().set({
     name: `${config.SESSION_PREFIX}-${state}`,
-    value: code_verifier,
+    value: JSON.stringify({code_verifier, options}),
     httpOnly: true,
     path: '/',
     maxAge: 60 * 15


### PR DESCRIPTION
# Explain your changes
- enable devs to set a `post_login_redirect_url` query param in the app router to determine where a user is redirected after logging in.

- baked it into the LoginLink + RegisterLink too with prop `postLoginRedirectURL`
_Suppose there is a related issue with enough detail for a reviewer to understand your changes fully. In that case, you can omit an explanation and instead include either “Fixes #XX” or “Updates #XX” where “XX” is the issue number._

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
