### PR TITLE
fix: reletting the api token

### DIFF
--- a/src/api-client.js
+++ b/src/api-client.js
@@ -45,7 +45,7 @@ export const createKindeManagementAPIClient = async (req, res) => {
         audience: config.audience
       })
     });
-    let apiToken = (await response.json()).access_token;
+    apiToken = (await response.json()).access_token;
     store.setSessionItem('kinde_api_access_token', apiToken);
   }
 


### PR DESCRIPTION
# Explain your changes
- keep only one`apiToken` variable - was reinitializing it instead of overriding it's value
_Suppose there is a related issue with enough detail for a reviewer to understand your changes fully. In that case, you can omit an explanation and instead include either “Fixes #XX” or “Updates #XX” where “XX” is the issue number._

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
