### PR TITLE
Replace node:crypto with uncrypto

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,10 +10,10 @@
       "dependencies": {
         "@kinde-oss/kinde-typescript-sdk": "^2.2.0",
         "cookie": "^0.5.0",
-        "crypto": "^1.0.1",
         "crypto-js": "^4.1.1",
         "jwt-decode": "^3.1.2",
-        "simple-oauth2": "^4.3.0"
+        "simple-oauth2": "^4.3.0",
+        "uncrypto": "^0.1.3"
       },
       "devDependencies": {
         "@babel/core": "^7.17.12",
@@ -1822,12 +1822,6 @@
       "engines": {
         "node": ">= 8"
       }
-    },
-    "node_modules/crypto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/crypto/-/crypto-1.0.1.tgz",
-      "integrity": "sha512-VxBKmeNcqQdiUQUW2Tzq0t377b54N2bMtXO/qiLa+6eRRmmC4qT3D4OnTGoT/U6O9aklQ/jTwbOtRMTTY8G0Ig==",
-      "deprecated": "This package is no longer supported. It's now a built-in Node module. If you've depended on crypto, you should switch to the one that's built-in."
     },
     "node_modules/crypto-js": {
       "version": "4.1.1",
@@ -8294,11 +8288,6 @@
         "shebang-command": "^2.0.0",
         "which": "^2.0.1"
       }
-    },
-    "crypto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/crypto/-/crypto-1.0.1.tgz",
-      "integrity": "sha512-VxBKmeNcqQdiUQUW2Tzq0t377b54N2bMtXO/qiLa+6eRRmmC4qT3D4OnTGoT/U6O9aklQ/jTwbOtRMTTY8G0Ig=="
     },
     "crypto-js": {
       "version": "4.1.1",

--- a/package.json
+++ b/package.json
@@ -43,10 +43,10 @@
   "dependencies": {
     "@kinde-oss/kinde-typescript-sdk": "^2.2.0",
     "cookie": "^0.5.0",
-    "crypto": "^1.0.1",
     "crypto-js": "^4.1.1",
     "jwt-decode": "^3.1.2",
-    "simple-oauth2": "^4.3.0"
+    "simple-oauth2": "^4.3.0",
+    "uncrypto": "^0.1.3"
   },
   "files": [
     "LICENSE.md",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "typings": "index.d.ts",
   "scripts": {
     "build": "genversion --es6 src/utils/version.js && rollup -c",
+    "prepare": "genversion --es6 src/utils/version.js && rollup -c",
     "build:watch": "genversion --es6 src/utils/version.js && rollup -c -w",
     "test": "jest",
     "release": "release-it",

--- a/src/utils/randomString.js
+++ b/src/utils/randomString.js
@@ -1,3 +1,7 @@
-const crypto = require('crypto');
+const {getRandomValues} = require("uncrypto");
 
-export const randomString = () => crypto.randomBytes(28).toString('hex');
+export const randomString = () => {
+    const buffer = new Uint8Array(28);
+    getRandomValues(buffer);
+    return Array.from(buffer).map((n) => n.toString(16).padStart(2, "0")).join("");
+}

--- a/src/utils/sha256.js
+++ b/src/utils/sha256.js
@@ -1,4 +1,4 @@
-const {subtle} = require('crypto');
+const {subtle} = require('uncrypto');
 // Calculate the SHA256 hash of the input text.
 // Returns a promise that resolves to an ArrayBuffer
 export function sha256(plain) {


### PR DESCRIPTION
# Explain your changes

I replaced the two usages of Node.js crypto with uncrypto as it is already used in the typescript sdk, which this package depends on. This should allow Next.js apps using Kinde to run on the Vercel Edge Runtime and other platforms which don't support Node.js APIs.

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).
