### PR TITLE
Make sure always a single slash between domain and path in callbacks

### DIFF
--- a/src/authMiddleware/authMiddleware.js
+++ b/src/authMiddleware/authMiddleware.js
@@ -3,7 +3,7 @@ import {NextResponse} from 'next/server';
 import {config} from '../config/index';
 
 const trimTrailingSlash = (str) =>
-  str.charAt(str.length - 1) === '/' ? str.slice(0, -1) : str;
+  str && str.charAt(str.length - 1) === '/' ? str.slice(0, -1) : str;
 
 export function authMiddleware(request) {
   let isAuthenticated = false;

--- a/src/handlers/appRouter/callback.js
+++ b/src/handlers/appRouter/callback.js
@@ -4,6 +4,7 @@ import {version} from '../../utils/version';
 import {cookies} from 'next/headers';
 import {redirect} from 'next/navigation';
 import {sanitizeRedirect} from '../../utils/sanitizeRedirect';
+import {generateCallbackUrl} from '../../utils/generateCallbackUrl';
 
 export const callback = async (request) => {
   const code = request.nextUrl.searchParams.get('code');
@@ -39,7 +40,10 @@ export const callback = async (request) => {
             code: code,
             code_verifier: code_verifier,
             grant_type: 'authorization_code',
-            redirect_uri: `${config.redirectURL}${config.redirectRoutes.callback}`
+            redirect_uri: generateCallbackUrl(
+              config.redirectURL,
+              config.redirectRoutes.callback
+            )
           })
         }
       );

--- a/src/handlers/pageRouter/callback.js
+++ b/src/handlers/pageRouter/callback.js
@@ -4,6 +4,7 @@ import {config} from '../../config/index';
 import {isTokenValid} from '../../utils/pageRouter/isTokenValid';
 import {version} from '../../utils/version';
 import {sanitizeRedirect} from '../../utils/sanitizeRedirect';
+import {generateCallbackUrl} from '../../utils/generateCallbackUrl';
 
 var cookie = require('cookie');
 
@@ -17,10 +18,7 @@ export const callback = async (req, res) => {
 
   if (jsonCookieValue) {
     try {
-      const {
-        code_verifier,
-        options,
-      } = JSON.parse(jsonCookieValue);
+      const {code_verifier, options} = JSON.parse(jsonCookieValue);
 
       if (options?.post_login_redirect_url) {
         redirectUrl = sanitizeRedirect({
@@ -43,7 +41,10 @@ export const callback = async (req, res) => {
             code,
             code_verifier,
             grant_type: 'authorization_code',
-            redirect_uri: config.redirectURL + config.redirectRoutes.callback
+            redirect_uri: generateCallbackUrl(
+              config.redirectURL,
+              config.redirectRoutes.callback
+            )
           })
         }
       );

--- a/src/utils/generateAuthUrl.js
+++ b/src/utils/generateAuthUrl.js
@@ -1,11 +1,15 @@
 import {config} from '../config/index';
+import {generateCallbackUrl} from '../utils/generateCallbackUrl';
 
 export function generateAuthUrl(options, type = 'login') {
   const {org_code, is_create_org, org_name = ''} = options;
   const authUrl = new URL(config.issuerURL + config.issuerRoutes[type]);
 
   let searchParams = {
-    redirect_uri: config.redirectURL + config.redirectRoutes.callback,
+    redirect_uri: generateCallbackUrl(
+      config.redirectURL,
+      config.redirectRoutes.callback
+    ),
     client_id: config.clientID,
     response_type: config.responseType,
     scope: config.scope,

--- a/src/utils/generateCallbackUrl.js
+++ b/src/utils/generateCallbackUrl.js
@@ -1,0 +1,7 @@
+const generateCallbackUrl = (base, path) => {
+  const siteUrl = base.endsWith('/') ? base.slice(0, -1) : base;
+  const callbackPath = path.startsWith('/') ? path.substr(1) : path;
+  return `${siteUrl}/${callbackPath}`;
+};
+
+export {generateCallbackUrl};


### PR DESCRIPTION
# Explain your changes

Commonly finding people have `//` between their domains and paths when deploying to services like Vercel that seem to add a trailing slash at build time.

Added a function to create callback URLs which ensures there is always a single slash between domain and path

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
