### PR TITLE
Peter/backwards compatibilty get token

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,7 @@ You can also use the NextJS starter kit [here](https://github.com/kinde-starter
 
 ## Documentation
 
-Please refer to the Kinde [NextJS SDK document](https://kinde.com/docs/developer-tools/nextjs-sdk).
+Please refer to the Kinde [NextJS SDK document](https://kinde.notion.site/Next-js-App-Router-v2-e7a16d8ae38e45b6ad052910075e24ef?pvs=4).
 
 ## Publishing
 

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -8,10 +8,12 @@ const initialState = {
   accessToken: null,
   getClaim: null,
   getFlag: null,
+  getToken: null,
   getBooleanFlag: null,
   getStringFlag: null,
   getIntegerFlag: null,
   getPermission: null,
+  getPermissions: null,
   permissions: null,
   organization: null,
   userOrganizations: null

--- a/src/frontend/AuthProvider.jsx
+++ b/src/frontend/AuthProvider.jsx
@@ -107,6 +107,11 @@ const handleError = () => {
  */
 
 /**
+ * @callback getToken
+ * @return {string | null}
+ */
+
+/**
  * @callback getIdToken
  * @return {IdToken}
  */
@@ -144,6 +149,7 @@ const handleError = () => {
  * @property {getPermission} getPermission
  * @property {getStringFlag} getStringFlag
  * @property {getAccessToken} getAccessToken
+ * @property {getToken} getToken
  * @property {getPermissions} getPermissions
  * @property {getOrganization} getOrganization
  * @property {getUserOrganzations} getUserOrganzations
@@ -197,8 +203,7 @@ const tokenFetcher = async (url) => {
  */
 export const KindeProvider = ({children}) => {
   const [state, setState] = useState({
-    ...config.initialState,
-    getToken: () => null
+    ...config.initialState
   });
 
   const setupUrl = `${config.apiPath}/setup`;
@@ -215,9 +220,11 @@ export const KindeProvider = ({children}) => {
         userOrganizations,
         featureFlags,
         accessToken,
+        accessTokenEncoded,
         idToken
       } = tokens;
 
+      const getToken = () => accessTokenEncoded;
       const getAccessToken = () => accessToken;
       const getIdToken = () => idToken;
       const getPermissions = () => permissions;
@@ -298,6 +305,7 @@ export const KindeProvider = ({children}) => {
         organization,
         userOrganizations,
         getAccessToken,
+        getToken,
         getClaim,
         getFlag,
         getIdToken,
@@ -335,6 +343,7 @@ export const KindeProvider = ({children}) => {
     accessToken,
     idToken,
     getAccessToken,
+    getToken,
     getClaim,
     getFlag,
     getIdToken,
@@ -360,6 +369,7 @@ export const KindeProvider = ({children}) => {
         accessToken,
         idToken,
         getAccessToken,
+        getToken,
         getClaim,
         getFlag,
         getIdToken,

--- a/src/frontend/KindeBrowserClient.js
+++ b/src/frontend/KindeBrowserClient.js
@@ -8,6 +8,7 @@ import {flagDataTypeMap} from './AuthProvider.jsx';
 export const useKindeBrowserClient = () => {
   const [state, setState] = useState({
     accessToken: null,
+    accessTokenEncoded: null,
     error: null,
     featureFlags: [],
     idToken: null,
@@ -96,6 +97,9 @@ export const useKindeBrowserClient = () => {
   const getAccessToken = () => {
     return state.accessToken;
   };
+  const getToken = () => {
+    return state.accessTokenEncoded;
+  };
   const getIdToken = () => {
     return state.idToken;
   };
@@ -124,6 +128,7 @@ export const useKindeBrowserClient = () => {
     getStringFlag,
     getClaim,
     getAccessToken,
+    getToken,
     getIdToken,
     getOrganization,
     getPermissions,

--- a/src/handlers/setup.js
+++ b/src/handlers/setup.js
@@ -9,6 +9,10 @@ export const setup = async (routerClient) => {
       'id_token_payload'
     );
 
+    const accessTokenEncoded = await routerClient.sessionManager.getSessionItem(
+      'access_token'
+    );
+
     const permissions = await routerClient.kindeClient.getClaimValue(
       routerClient.sessionManager,
       'permissions'
@@ -32,6 +36,7 @@ export const setup = async (routerClient) => {
 
     return routerClient.json({
       accessToken,
+      accessTokenEncoded,
       idToken,
       user,
       permissions,


### PR DESCRIPTION
# Explain your changes
- make `getToken` helper available from `useKindeAuth` + `useKindeBrowserClient` for backwards compatibility with v1
_Suppose there is a related issue with enough detail for a reviewer to understand your changes fully. In that case, you can omit an explanation and instead include either “Fixes #XX” or “Updates #XX” where “XX” is the issue number._

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
