### PR TITLE
fix: register takes you to register page (not login)

### DIFF
--- a/src/handlers/register.js
+++ b/src/handlers/register.js
@@ -1,5 +1,5 @@
 export const register = async (routerClient) => {
-  const authUrl = await routerClient.kindeClient.login(
+  const authUrl = await routerClient.kindeClient.register(
     routerClient.sessionManager,
     {
       authUrlParams: Object.fromEntries(routerClient.searchParams)


### PR DESCRIPTION
# Explain your changes
- register was taking end users to the login page -> now it should take them to the register page
_Suppose there is a related issue with enough detail for a reviewer to understand your changes fully. In that case, you can omit an explanation and instead include either “Fixes #XX” or “Updates #XX” where “XX” is the issue number._

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
