### PR TITLE
add login hint to the auth urls

### DIFF
--- a/src/utils/generateAuthUrl.js
+++ b/src/utils/generateAuthUrl.js
@@ -2,7 +2,7 @@ import {config} from '../config/index';
 import {generateCallbackUrl} from '../utils/generateCallbackUrl';
 
 export function generateAuthUrl(options, type = 'login') {
-  const {org_code, is_create_org, org_name = ''} = options;
+  const {org_code, is_create_org, org_name = '', login_hint} = options;
   const authUrl = new URL(config.issuerURL + config.issuerRoutes[type]);
 
   let searchParams = {
@@ -24,6 +24,10 @@ export function generateAuthUrl(options, type = 'login') {
 
   if (org_code) {
     searchParams.org_code = org_code;
+  }
+
+  if (login_hint) {
+    searchParams.login_hint = login_hint
   }
 
   if (is_create_org) {


### PR DESCRIPTION
# Explain your changes

This passes the login_hint down to the auth flow to allow pre-filling emails on the pages flow.  This is a 1.x fix

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
