### PR TITLE
fix: move router type definitions

### DIFF
--- a/src/routerClients/RouterClient.js
+++ b/src/routerClients/RouterClient.js
@@ -1,23 +1,24 @@
 import {NextResponse} from 'next/server';
 
 export default class RouterClient {
+  /** @type {import('../../types').KindeClient} */
+  kindeClient = null;
+  /** @type {URL} */
+  url;
+  /** @type {import('@kinde-oss/kinde-typescript-sdk').SessionManager} */
+  sessionManager;
+  /** @type {import('next').NextApiResponse | *} */
+  res;
+  /** @type {import('next').NextApiRequest | NextResponse | *} */
+  req;
+  /** @type {URLSearchParams} */
+  searchParams;
+ 
   constructor() {
     if (this.constructor == RouterClient) {
       throw new Error("Abstract classes can't be instantiated.");
     }
-    /** @type {import('../../types').KindeClient} */
-    this.kindeClient;
-    /** @type {URL} */
-    this.url;
-    /** @type {import('@kinde-oss/kinde-typescript-sdk').SessionManager} */
-    this.sessionManager;
-    /** @type {import('next').NextApiResponse | *} */
-    this.res;
-    /** @type {import('next').NextApiRequest | NextResponse | *} */
-    this.req;
-    /** @type {URLSearchParams} */
-    this.searchParams;
-  }
+   }
 
   /**
    *


### PR DESCRIPTION
# Explain your changes

The class property definitions should happen at root level not inside the constructor.

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
