### PR TITLE
Added properties to KindeAccessToken type

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -16,7 +16,10 @@ export type KindeAccessToken = {
   iss: string;
   jti: string;
   org_code: string;
+  org_name?: string;
   permissions: KindePermissions;
+  roles?: KindeRole[];
+  email?: string;
   scp: string[];
   sub: string;
 };
@@ -56,6 +59,12 @@ export type KindePermission = {
   isGranted: boolean;
   orgCode: string | null;
 };
+
+export type KindeRole = {
+  id: string;
+  key: string;
+  name: string;
+}
 
 export type KindeFlagRaw = {
   t: KindeFlagTypeCode;


### PR DESCRIPTION
Added properties to KindeAccessToken type to support access token customization fields

# Explain your changes

In the Kinde application settings you can customize the access token to add additional claims. These claims are not present in the KindeAccessToken type so with this PR these claims are added to the KindeAccessToken type as extra properties.  This resolves typing errors when trying to access these properties.

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced user access tokens to include organization name, roles, and email information for improved user management and authentication experiences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->