### PR TITLE
feat: expose publicPaths via options param

### DIFF
--- a/src/authMiddleware/authMiddleware.js
+++ b/src/authMiddleware/authMiddleware.js
@@ -36,7 +36,7 @@ const handleMiddleware = async (req, options, onSuccess) => {
 
   const isReturnToCurrentPage = options?.isReturnToCurrentPage;
   const loginPage = options?.loginPage || '/api/auth/login';
-  const publicPaths = ['/_next', '/favicon.ico'];
+  const publicPaths = options?.publicPaths || ['/_next', '/favicon.ico'];
 
   const loginRedirectUrl = isReturnToCurrentPage
     ? `${loginPage}?post_login_redirect_url=${pathname}`

--- a/src/authMiddleware/authMiddleware.js
+++ b/src/authMiddleware/authMiddleware.js
@@ -36,7 +36,13 @@ const handleMiddleware = async (req, options, onSuccess) => {
 
   const isReturnToCurrentPage = options?.isReturnToCurrentPage;
   const loginPage = options?.loginPage || '/api/auth/login';
-  const publicPaths = options?.publicPaths || ['/_next', '/favicon.ico'];
+
+  let publicPaths = ['/_next', '/favicon.ico'];
+  if (options?.publicPaths !== undefined) {
+    if (Array.isArray(options?.publicPaths)) {
+      publicPaths = options.publicPaths;
+    }
+  }
 
   const loginRedirectUrl = isReturnToCurrentPage
     ? `${loginPage}?post_login_redirect_url=${pathname}`


### PR DESCRIPTION
# Explain your changes
- Expose `publicPaths` via options params in auth middleware
- Allow users to define `publicPaths` or default to something sensible

_Suppose there is a related issue with enough detail for a reviewer to understand your changes fully. In that case, you can omit an explanation and instead include either “Fixes #XX” or “Updates #XX” where “XX” is the issue number._

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Enhanced the flexibility of specifying public paths in authentication middleware through customization options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->