### PR TITLE
Peter/feat refresh tokens

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.1.15",
       "dependencies": {
         "@babel/preset-env": "^7.23.9",
-        "@kinde-oss/kinde-typescript-sdk": "^2.6.2",
+        "@kinde-oss/kinde-typescript-sdk": "^2.8.0",
         "cookie": "^0.5.0",
         "crypto-js": "^4.1.1",
         "jwt-decode": "^3.1.2",
@@ -2615,8 +2615,9 @@
       }
     },
     "node_modules/@kinde-oss/kinde-typescript-sdk": {
-      "version": "2.6.2",
-      "license": "MIT",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@kinde-oss/kinde-typescript-sdk/-/kinde-typescript-sdk-2.8.0.tgz",
+      "integrity": "sha512-LafkGPLVVfunIgnXwmiDDubeOsp+ypcT3mI17ffepaXoBAyjtfxX/bb96f3ThR1VZ4Gsy3LeladduYnyhxPFRg==",
       "dependencies": {
         "jwt-decode": "^4.0.0",
         "uncrypto": "^0.1.3"

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   },
   "dependencies": {
     "@babel/preset-env": "^7.23.9",
-    "@kinde-oss/kinde-typescript-sdk": "^2.6.2",
+    "@kinde-oss/kinde-typescript-sdk": "^2.8.0",
     "cookie": "^0.5.0",
     "crypto-js": "^4.1.1",
     "jwt-decode": "^3.1.2",

--- a/src/authMiddleware/authMiddleware.js
+++ b/src/authMiddleware/authMiddleware.js
@@ -36,7 +36,7 @@ const handleMiddleware = async (req, options, onSuccess) => {
 
   const isReturnToCurrentPage = options?.isReturnToCurrentPage;
   const loginPage = options?.loginPage || '/api/auth/login';
-  const publicPaths = ['/_next', '/favicon.ico'];
+  const publicPaths = options?.publicPaths || ['/_next', '/favicon.ico'];
 
   const loginRedirectUrl = isReturnToCurrentPage
     ? `${loginPage}?post_login_redirect_url=${pathname}`

--- a/src/authMiddleware/authMiddleware.js
+++ b/src/authMiddleware/authMiddleware.js
@@ -36,7 +36,13 @@ const handleMiddleware = async (req, options, onSuccess) => {
 
   const isReturnToCurrentPage = options?.isReturnToCurrentPage;
   const loginPage = options?.loginPage || '/api/auth/login';
-  const publicPaths = options?.publicPaths || ['/_next', '/favicon.ico'];
+
+  let publicPaths = ['/_next', '/favicon.ico'];
+  if (options?.publicPaths !== undefined) {
+    if (Array.isArray(options?.publicPaths)) {
+      publicPaths = options.publicPaths;
+    }
+  }
 
   const loginRedirectUrl = isReturnToCurrentPage
     ? `${loginPage}?post_login_redirect_url=${pathname}`

--- a/src/session/index.js
+++ b/src/session/index.js
@@ -23,7 +23,17 @@ import {sessionManager} from './sessionManager';
  */
 export default function (req, res) {
   return {
-    refreshTokens: () => kindeClient.refreshTokens(sessionManager(req, res)),
+    refreshTokens: async () => {
+      try {
+        const response = await kindeClient.refreshTokens(
+          sessionManager(req, res)
+        );
+        return response;
+      } catch (error) {
+        console.error('Error refreshing tokens', error);
+        return null;
+      }
+    },
     getAccessToken: getAccessTokenFactory(req, res),
     getBooleanFlag: getBooleanFlagFactory(req, res),
     getFlag: getFlagFactory(req, res),

--- a/src/session/index.js
+++ b/src/session/index.js
@@ -12,6 +12,8 @@ import {getUserOrganizationsFactory} from './getUserOrganizations';
 import {isAuthenticatedFactory} from './isAuthenticated';
 import {getAccessTokenRawFactory} from './getAccessTokenRaw';
 import {getIdTokenRawFactory} from './getIdTokenRaw';
+import {kindeClient} from './kindeServerClient';
+import {sessionManager} from './sessionManager';
 
 /**
  *
@@ -21,6 +23,7 @@ import {getIdTokenRawFactory} from './getIdTokenRaw';
  */
 export default function (req, res) {
   return {
+    refreshTokens: () => kindeClient.refreshTokens(sessionManager(req, res)),
     getAccessToken: getAccessTokenFactory(req, res),
     getBooleanFlag: getBooleanFlagFactory(req, res),
     getFlag: getFlagFactory(req, res),


### PR DESCRIPTION
# Explain your changes
- allow users to refresh tokens by using `getKindeServerSession().refreshTokens()` - it uses the refresh token to get up to date token data from kinde
- upgrade TS SDK version
_Suppose there is a related issue with enough detail for a reviewer to understand your changes fully. In that case, you can omit an explanation and instead include either “Fixes #XX” or “Updates #XX” where “XX” is the issue number._

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced authentication middleware to support customizable public paths.
	- Introduced a new method for token refresh in session management.
	- Added `kindeClient` and `sessionManager` imports for improved functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->