### PR TITLE
fix: getPermission & getUser

### DIFF
--- a/src/frontend/KindeBrowserClient.js
+++ b/src/frontend/KindeBrowserClient.js
@@ -192,8 +192,15 @@ export const useKindeBrowserClient = (
    * @returns {import('../../types.js').KindePermission}
    */
   const getPermission = (key) => {
+    if (!state.permissions) {
+      return {
+        isGranted: false,
+        orgCode: null
+      };
+    }
+
     return {
-      isGranted: state.permissions.permissions.some((p) => p === key),
+      isGranted: state.permissions.permissions?.some((p) => p === key),
       orgCode: state.organization
     };
   };
@@ -201,6 +208,7 @@ export const useKindeBrowserClient = (
   return {
     ...state,
     isAuthenticated: !!state.user,
+    getUser: () => state.user,
     getIdTokenRaw,
     getPermission,
     getBooleanFlag,

--- a/src/frontend/KindeBrowserClient.js
+++ b/src/frontend/KindeBrowserClient.js
@@ -192,12 +192,7 @@ export const useKindeBrowserClient = (
    * @returns {import('../../types.js').KindePermission}
    */
   const getPermission = (key) => {
-    if (!state.permissions) {
-      return {
-        isGranted: false,
-        orgCode: null
-      };
-    }
+    if (!state.permissions) return { isGranted: false, orgCode: null };
 
     return {
       isGranted: state.permissions.permissions?.some((p) => p === key),


### PR DESCRIPTION
# Explain your changes
- getPermissions check if permissions exist before running array operations
- getUser -> made sure to export from useKindeBrowserClient as stated in the TS declaration file


# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Bug Fixes**
	- Improved handling of missing permissions data to ensure functionality remains robust.
- **New Features**
	- Added functionality to retrieve user information directly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->