### PR TITLE
feature: implenment aunthentication function to protect Page components

### DIFF
--- a/src/handlers/protect.js
+++ b/src/handlers/protect.js
@@ -53,7 +53,6 @@ export const protectPage =
       }
     } catch (error) {
       console.error('Error protecting page', error);
-      // return redirect(config.redirect);
       return null;
     }
 
@@ -109,10 +108,6 @@ export const protectApi = (handler, config) => async (req) => {
     }
   } catch (error) {
     console.error('Error protecting page', error);
-    // return NextResponse.json({
-    //   statusCode: 500,
-    //   message: 'Internal Server Error'
-    // });
     return null;
   }
 

--- a/src/handlers/protect.js
+++ b/src/handlers/protect.js
@@ -1,5 +1,5 @@
-export { default as getKindeServerSession } from '../session/index';
-import { redirect } from 'next/navigation'
+export {default as getKindeServerSession} from '../session/index';
+import {redirect} from 'next/navigation';
 
 /**
  * A higher-order function that wraps a page component and adds protection logic.
@@ -12,38 +12,41 @@ import { redirect } from 'next/navigation'
  * @returns {Function} - The protected page component.
  */
 
-const protectPage = (page, config = { redirect: '/api/login', statusCode: 302 }) => async (props) => {
-    const { isAuthenticated, getAccessToken,  getPermission } = kinde()
-    const isSignedIn = await isAuthenticated()
-  
+const protectPage =
+  (page, config = {redirect: '/api/login', statusCode: 302}) =>
+  async (props) => {
+    const {isAuthenticated, getAccessToken, getPermission} = kinde();
+    const isSignedIn = await isAuthenticated();
+
     if (!isSignedIn) {
-      return redirect(config.redirect, { statusCode: 302 })
+      return redirect(config.redirect, {statusCode});
     }
 
     if (config.role) {
-        const token = await getAccessToken()
-        const roles = token?.roles
-        if (!roles || !config.role.some((role) => roles.includes(role))) {
-          return redirect(config.redirect, { statusCode: 302 })
-        }
+      const token = await getAccessToken();
+      const roles = token?.roles;
+      if (!roles || !config.role.some((role) => roles.includes(role))) {
+        return redirect(config.redirect, {statusCode});
+      }
     }
 
-    if (typeof config.permissions === "string") {
-        const hasPermission = await getPermission(config.permissions)
-        if (!hasPermission) {
-          return redirect(config.redirect, { statusCode: 302 })
-        }
-
+    if (typeof config.permissions === 'string') {
+      const hasPermission = await getPermission(config.permissions);
+      if (!hasPermission) {
+        return redirect(config.redirect, {statusCode});
+      }
     }
 
     if (Array.isArray(config.permissions)) {
-        const hasPermission = await Promise.all(config.permissions.map((permission) => getPermission(permission)))
-        if (!hasPermission.some((permission) => permission)) {
-          return redirect(config.redirect, { statusCode: 302 })
-        }
+      const hasPermission = await Promise.all(
+        config.permissions.map((permission) => getPermission(permission))
+      );
+      if (!hasPermission.some((permission) => permission)) {
+        return redirect(config.redirect, {statusCode});
+      }
     }
-  
-    return page(props)
-}
-  
-export default protectPage
+
+    return page(props);
+  };
+
+export default protectPage;

--- a/src/handlers/protect.js
+++ b/src/handlers/protect.js
@@ -15,7 +15,8 @@ import {redirect} from 'next/navigation';
 const protectPage =
   (page, config = {redirect: '/api/login', statusCode: 302}) =>
   async (props) => {
-    const {isAuthenticated, getAccessToken, getPermission} = kinde();
+    const {isAuthenticated, getAccessToken, getPermission, getPermissions} =
+      kinde();
     const isSignedIn = await isAuthenticated();
 
     if (!isSignedIn) {
@@ -38,10 +39,12 @@ const protectPage =
     }
 
     if (Array.isArray(config.permissions)) {
-      const hasPermission = await Promise.all(
-        config.permissions.map((permission) => getPermission(permission))
-      );
-      if (!hasPermission.some((permission) => permission)) {
+      const permissions = await getPermissions();
+      if (
+        !config.permissions.some((permission) =>
+          permissions.includes(permission)
+        )
+      ) {
         return redirect(config.redirect, {statusCode});
       }
     }

--- a/src/handlers/protect.js
+++ b/src/handlers/protect.js
@@ -7,7 +7,7 @@ import {NextResponse} from 'next/server';
  * @param {import('react').ReactNode} page - The page component to be protected.
  * @param {Object} config - The configuration options for the protection logic.
  * @param {string} config.redirect - The redirect path if the user is not authenticated or does not have the required role or permissions.
- * @param {string[]} config.role - The required role(s) for accessing the protected page.
+ * @param {string[]} config.roles - The required role(s) for accessing the protected page.
  * @param {string|string[]} config.permissions - The required permission(s) for accessing the protected page.
  * @returns {Function} - The protected page component.
  */
@@ -24,12 +24,12 @@ export const protectPage =
         return redirect(config.redirect);
       }
 
-      if (config.role) {
+      if (config.roles) {
         const token = await getAccessToken();
         const roles = token?.roles;
         if (!roles) return redirect(config.redirect);
         const roleNames = new Set(roles.map((r) => r.name));
-        if (!config.role.some((role) => roleNames.has(role))) {
+        if (!config.roles.some((role) => roleNames.has(role))) {
           return redirect(config.redirect);
         }
       }
@@ -64,7 +64,7 @@ export const protectPage =
  * Protects a Next.js API route handler with authentication and authorization.
  * @param {Function} handler - The Next.js API route handler.
  * @param {Object} config - The configuration object.
- * @param {string[]} config.role - The required role(s) for accessing the protected page.
+ * @param {string[]} config.roles - The required role(s) for accessing the protected page.
  * @param {string|string[]} config.permissions - The required permission(s) for accessing the protected page.
  * @returns {Function} - The protected API route handler.
  */
@@ -79,13 +79,13 @@ export const protectApi = (handler, config) => async (req) => {
       return NextResponse.json({statusCode: 401, message: 'Unauthorized'});
     }
 
-    if (config.role) {
+    if (config.roles) {
       const token = await getAccessToken();
       const roles = token?.roles;
       if (!roles)
         return NextResponse.json({statusCode: 401, message: 'Unauthorized'});
       const roleNames = new Set(roles.map((r) => r.name));
-      if (!config.role.some((role) => roleNames.has(role))) {
+      if (!config.roles.some((role) => roleNames.has(role))) {
         return NextResponse.json({statusCode: 401, message: 'Unauthorized'});
       }
     }

--- a/src/handlers/protect.js
+++ b/src/handlers/protect.js
@@ -13,7 +13,7 @@ import {redirect} from 'next/navigation';
  */
 
 const protectPage =
-  (page, config = {redirect: '/api/login', statusCode: 302}) =>
+  (page, config = {redirect: '/api/auth/login', statusCode: 302}) =>
   async (props) => {
     const {isAuthenticated, getAccessToken, getPermission, getPermissions} =
       kinde();

--- a/src/handlers/protect.js
+++ b/src/handlers/protect.js
@@ -1,0 +1,49 @@
+export { default as getKindeServerSession } from '../session/index';
+import { redirect } from 'next/navigation'
+
+/**
+ * A higher-order function that wraps a page component and adds protection logic.
+ * @param {import('react').ReactNode} page - The page component to be protected.
+ * @param {Object} config - The configuration options for the protection logic.
+ * @param {string} config.redirect - The redirect path if the user is not authenticated or does not have the required role or permissions.
+ * @param {string[]} config.role - The required role(s) for accessing the protected page.
+ * @param {string|string[]} config.permissions - The required permission(s) for accessing the protected page.
+ * @param {number} config.statusCode - The status code for the redirect response.
+ * @returns {Function} - The protected page component.
+ */
+
+const protectPage = (page, config = { redirect: '/api/login', statusCode: 302 }) => async (props) => {
+    const { isAuthenticated, getAccessToken,  getPermission } = kinde()
+    const isSignedIn = await isAuthenticated()
+  
+    if (!isSignedIn) {
+      return redirect(config.redirect, { statusCode: 302 })
+    }
+
+    if (config.role) {
+        const token = await getAccessToken()
+        const roles = token?.roles
+        if (!roles || !config.role.some((role) => roles.includes(role))) {
+          return redirect(config.redirect, { statusCode: 302 })
+        }
+    }
+
+    if (typeof config.permissions === "string") {
+        const hasPermission = await getPermission(config.permissions)
+        if (!hasPermission) {
+          return redirect(config.redirect, { statusCode: 302 })
+        }
+
+    }
+
+    if (Array.isArray(config.permissions)) {
+        const hasPermission = await Promise.all(config.permissions.map((permission) => getPermission(permission)))
+        if (!hasPermission.some((permission) => permission)) {
+          return redirect(config.redirect, { statusCode: 302 })
+        }
+    }
+  
+    return page(props)
+}
+  
+export default protectPage

--- a/src/handlers/protect.js
+++ b/src/handlers/protect.js
@@ -17,36 +17,42 @@ const protectPage =
   async (props) => {
     const {isAuthenticated, getAccessToken, getPermission, getPermissions} =
       kinde();
-    const isSignedIn = await isAuthenticated();
+    try {
+      const isSignedIn = await isAuthenticated();
 
-    if (!isSignedIn) {
-      return redirect(config.redirect, {statusCode});
-    }
-
-    if (config.role) {
-      const token = await getAccessToken();
-      const roles = token?.roles;
-      if (!roles || !config.role.some((role) => roles.includes(role))) {
+      if (!isSignedIn) {
         return redirect(config.redirect, {statusCode});
       }
-    }
 
-    if (typeof config.permissions === 'string') {
-      const hasPermission = await getPermission(config.permissions);
-      if (!hasPermission) {
-        return redirect(config.redirect, {statusCode});
+      if (config.role) {
+        const token = await getAccessToken();
+        const roles = token?.roles;
+        if (!roles || !config.role.some((role) => roles.includes(role))) {
+          return redirect(config.redirect, {statusCode});
+        }
       }
-    }
 
-    if (Array.isArray(config.permissions)) {
-      const permissions = await getPermissions();
-      if (
-        !config.permissions.some((permission) =>
-          permissions.includes(permission)
-        )
-      ) {
-        return redirect(config.redirect, {statusCode});
+      if (typeof config.permissions === 'string') {
+        const hasPermission = await getPermission(config.permissions);
+        if (!hasPermission) {
+          return redirect(config.redirect, {statusCode});
+        }
       }
+
+      if (Array.isArray(config.permissions)) {
+        const permissions = await getPermissions();
+        if (
+          !config.permissions.some((permission) =>
+            permissions.includes(permission)
+          )
+        ) {
+          return redirect(config.redirect, {statusCode});
+        }
+      }
+    } catch (error) {
+      // return redirect(config.redirect, {statusCode});
+      console.error('Error protecting page', error);
+      return null;
     }
 
     return page(props);

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -7,5 +7,5 @@ export {
   RegisterLink
 } from '../components/index';
 export {createKindeManagementAPIClient} from '../api-client';
-export { default as handleAuth } from '../handlers/auth';
-export { default as protectPage} from '../handlers/protect';
+export {default as handleAuth} from '../handlers/auth';
+export {default as protectPage} from '../handlers/protect';

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -7,4 +7,5 @@ export {
   RegisterLink
 } from '../components/index';
 export {createKindeManagementAPIClient} from '../api-client';
-export {default as handleAuth} from '../handlers/auth';
+export { default as handleAuth } from '../handlers/auth';
+export { default as protectPage} from '../handlers/protect';

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -8,4 +8,4 @@ export {
 } from '../components/index';
 export {createKindeManagementAPIClient} from '../api-client';
 export {default as handleAuth} from '../handlers/auth';
-export {default as protectPage} from '../handlers/protect';
+export {protectPage, protectApi} from '../handlers/protect';


### PR DESCRIPTION
# Adding a protectPage function

Adding a function to wrap a Page component that will implement basic authentication on a component level instead of using a middleware or rewriting authentication logic in every component you want to protect.

The reason I think this is a valuable contribution is because a big part of component development is that you don't separate by concerns but rather by functionality. moving the authentication to a separate file (middleware.ts) I think kinda contradicts that. On the other hand, writing the authentication logic in every protected route can get really repetitive so being able to authenticate in the page file but also not rewrite code possibly tens of times in a project is a useful feature.

the way it would be used is 

```js
const Page = () => <h1> for users only </h1>

export default protectPage(Page)
```

This may also be a good option for protecting layouts so you can protect any nested routes under it. 

I also added a way to check for roles and permissions that can be expanded on.

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new protection mechanism for page components, enhancing security by redirecting users based on authentication status and permissions.
	- Added the `protectPage` function to enforce protection logic.
	- Improved handling of authentication in the `handleAuth` export.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->