### PR TITLE
fix: getOrganization to return specified type

### DIFF
--- a/src/frontend/KindeBrowserClient.js
+++ b/src/frontend/KindeBrowserClient.js
@@ -196,7 +196,7 @@ export const useKindeBrowserClient = (
 
     return {
       isGranted: state.permissions.permissions?.some((p) => p === key),
-      orgCode: state.organization
+      orgCode: state.organization?.orgCode
     };
   };
 

--- a/src/handlers/setup.js
+++ b/src/handlers/setup.js
@@ -57,7 +57,9 @@ export const setup = async (routerClient) => {
         permissions,
         orgCode: organization
       },
-      organization,
+      organization: {
+        orgCode: organization
+      },
       featureFlags,
       userOrganizations
     });


### PR DESCRIPTION
# Explain your changes

Using `getOrganization()` from `useKindeBrowserClient` returns organization as a `string` instead of an object as specified in the types and `getOrganization()` from `getKindeServerSession`.

I.e.
```
const {getOrganization} = useKindeBrowserClient();
const org = getOrganization();
```

returns currently `org_abc123` instead of `{ orgCode: 'org_abc123' }`.  Similarly, `organization` returned from `useKindeBrowserClient` doesn't match the type.

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved handling of organization codes in browser client setup.
	- Enhanced structure of the organization object in setup configurations, ensuring more reliable data management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->