### PR TITLE
fix: add optional chainings to handleMiddleware function to avoid raising a TypeError

### DIFF
--- a/src/authMiddleware/authMiddleware.js
+++ b/src/authMiddleware/authMiddleware.js
@@ -55,7 +55,7 @@ const handleMiddleware = async (req, options, onSuccess) => {
 
   if (!kindeToken) {
     const response = NextResponse.redirect(
-      new URL(loginRedirectUrl, options.redirectURLBase || config.redirectURL)
+      new URL(loginRedirectUrl, options?.redirectURLBase || config.redirectURL)
     );
     return response;
   }
@@ -85,7 +85,7 @@ const handleMiddleware = async (req, options, onSuccess) => {
   }
 
   return NextResponse.redirect(
-    new URL(loginRedirectUrl, options.redirectURLBase || config.redirectURL)
+    new URL(loginRedirectUrl, options?.redirectURLBase || config.redirectURL)
   );
 };
 


### PR DESCRIPTION
# Adding optional chainings to avoid raising a TypeError

Since the commit 817d1b3 that was uploaded a day ago, a **TypeError** appeared with a simple setup of a Nextjs project and this library, specifically, by using the _withAuth_ middleware which is used to protect routes.

The error was the following: 
![image](https://github.com/kinde-oss/kinde-auth-nextjs/assets/54561501/072f8628-f602-48d1-8579-7e2ad88a317e)

By seeing the changes made, it seems the _redirectURLBase_ is indeed being read from an object that may be undefined; therefore, it only raises that error by using the middleware, at least, with a simple setup and use of _withAuth_ middleware. The variable ***option*** is not always passed to the ***handleMiddleware***, so that is why and where the error happens. 

While these changes can fix the issue, perhaps other features were trying to be implemented with the usage of the variable ***options***, so I'm not sure whether the variable ***options*** is mandatory across the global context of the project. However, since prior commits do not have that variable, I believe adding the optional chainings is enough to solve the issue as they are properly written on the same function on the lines that use the variable ***options***. 

For the record, within the ***handleMiddleware*** function, the optional chainings were missing on both return statements.

# Checklist

- [ ] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [ ] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
