### PR TITLE
fix: use host/environment variable if relative postLoginRedirectURL supplied

### DIFF
--- a/src/components/LoginLink.js
+++ b/src/components/LoginLink.js
@@ -24,16 +24,22 @@ export function LoginLink({
   let params = new URLSearchParams();
   let paramsObj = {};
   if (orgCode != null) paramsObj.org_code = orgCode;
-  if (postLoginRedirectURL != null)
+  if (postLoginRedirectURL != null) {
+    if (postLoginRedirectURL.startsWith('/')) {
+      const host = typeof window !== 'undefined' ? window.location.origin : process.env.KINDE_SITE_URL;
+      postLoginRedirectURL = `${host}${postLoginRedirectURL}`;
+    }
     paramsObj.post_login_redirect_url = postLoginRedirectURL;
+  }
 
   paramsObj = {...authUrlParams, ...paramsObj};
 
   for (const key in paramsObj) params.append(key, paramsObj[key]);
 
+  const authUrl = `${config.apiPath}/login${params ? `?${params.toString()}` : ''}`;
   return (
     <a
-      href={`${config.apiPath}/login${params ? `?${params.toString()}` : ''}`}
+      href={authUrl}
       {...props}
     >
       {children}

--- a/src/components/LoginLink.js
+++ b/src/components/LoginLink.js
@@ -21,7 +21,7 @@ export function LoginLink({
   authUrlParams,
   ...props
 }) {
-  let params = new URLSearchParams();
+  const params = new URLSearchParams();
   let paramsObj = {};
   if (orgCode != null) paramsObj.org_code = orgCode;
   if (postLoginRedirectURL != null) {


### PR DESCRIPTION
# Explain your changes

When reletive URL is passed to the `postLoginRedirectURL` property of login, append the host.

Resolves: https://github.com/kinde-oss/kinde-auth-nextjs/issues/174

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
