### PR TITLE
feat: on error callback fn

### DIFF
--- a/src/handlers/callback.js
+++ b/src/handlers/callback.js
@@ -16,12 +16,18 @@ export const callback = async (routerClient) => {
   const postLoginRedirectURL = postLoginRedirectURLFromMemory
     ? postLoginRedirectURLFromMemory
     : config.postLoginRedirectURL;
-
-  await routerClient.kindeClient.handleRedirectToApp(
-    routerClient.sessionManager,
-    routerClient.getUrl()
-  );
+  try {
+    await routerClient.kindeClient.handleRedirectToApp(
+      routerClient.sessionManager,
+      routerClient.getUrl()
+    );
+  } catch (error) {
+    routerClient.onError(error);
+    return routerClient.json({error: error.message}, {status: 500});
+  }
 
   if (typeof postLoginRedirectURL === 'string')
     return routerClient.redirect(postLoginRedirectURL);
+
+  return routerClient.redirect(config.redirectURL);
 };

--- a/src/handlers/callback.js
+++ b/src/handlers/callback.js
@@ -22,7 +22,6 @@ export const callback = async (routerClient) => {
       routerClient.getUrl()
     );
   } catch (error) {
-    routerClient.onError(error);
     return routerClient.json({error: error.message}, {status: 500});
   }
 

--- a/src/routerClients/AppRouterClient.js
+++ b/src/routerClients/AppRouterClient.js
@@ -11,8 +11,9 @@ export default class AppRouterClient extends RouterClient {
    *
    * @param {NextRequest} req
    * @param {*} res
+   * @param {{onError?: () => void}} options
    */
-  constructor(req, res) {
+  constructor(req, res, options) {
     super();
     this.kindeClient = createKindeServerClient(
       config.grantType,
@@ -22,6 +23,7 @@ export default class AppRouterClient extends RouterClient {
     this.sessionManager = appRouterSessionManager(cookies());
     this.req = req;
     this.searchParams = req.nextUrl.searchParams;
+    this.onErrorCallback = options?.onError;
   }
 
   /**
@@ -62,5 +64,11 @@ export default class AppRouterClient extends RouterClient {
    */
   getSearchParam(key) {
     return this.req.nextUrl.searchParams.get(key);
+  }
+
+  onError(error) {
+    if (this.onErrorCallback) {
+      this.onErrorCallback(error);
+    }
   }
 }

--- a/src/routerClients/RouterClient.js
+++ b/src/routerClients/RouterClient.js
@@ -13,12 +13,12 @@ export default class RouterClient {
   req;
   /** @type {URLSearchParams} */
   searchParams;
- 
+
   constructor() {
     if (this.constructor == RouterClient) {
       throw new Error("Abstract classes can't be instantiated.");
     }
-   }
+  }
 
   /**
    *
@@ -58,5 +58,9 @@ export default class RouterClient {
    */
   getSearchParam(key) {
     throw new Error("Method 'getSearchParam()' must be implemented.");
+  }
+
+  onError() {
+    throw new Error("Method 'onError()' must be implemented.");
   }
 }


### PR DESCRIPTION
# Explain your changes
- `onError` callback function can be passed into `handleAuth` to handle errors when handling redirect back to app during auth flow (state check) - *app router only*
- better error handling around environment variables - an error is thrown in client secret, client id, site url or issuer url are missing from `.env`

# Checklist

- [ x ] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [ x ] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
