### PR TITLE
fix: Post logout redirect URL

### DIFF
--- a/src/handlers/logout.js
+++ b/src/handlers/logout.js
@@ -1,3 +1,4 @@
+import { config } from '../config/index';
 import RouterClient from '../routerClients/RouterClient';
 
 /**
@@ -6,21 +7,15 @@ import RouterClient from '../routerClients/RouterClient';
  */
 export const logout = async (routerClient) => {
   const authUrl = await routerClient.kindeClient.logout(
-    routerClient.sessionManager,
-    {
-      authUrlParams: Object.fromEntries(routerClient.searchParams)
-    }
+    routerClient.sessionManager
   );
 
-  const postLogoutRedirectURL = routerClient.getSearchParam(
-    'post_logout_redirect_url'
-  );
-
+  let postLogoutRedirectURL = routerClient.getSearchParam('post_logout_redirect_url') || config.postLogoutRedirectURL;
+  if (postLogoutRedirectURL?.startsWith('/')) {
+    postLogoutRedirectURL = config.redirectURL + postLogoutRedirectURL;
+  }
   if (postLogoutRedirectURL) {
-    await routerClient.sessionManager.setSessionItem(
-      'post_logout_redirect_url',
-      postLogoutRedirectURL
-    );
+    authUrl.searchParams.set('redirect', postLogoutRedirectURL);
   }
 
   return routerClient.redirect(authUrl.toString());


### PR DESCRIPTION
# Explain your changes

- When supplying a post logout redirect URL to the logout component, this was not consumed and continued to use the environment variable regardless.
- When a relative URL is supplied the site URL will be appended.

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
