### PR TITLE
Fix: coalesce nulls when Hasura claims don't exist 

### DIFF
--- a/src/frontend/KindeBrowserClient.js
+++ b/src/frontend/KindeBrowserClient.js
@@ -23,7 +23,7 @@ export const useKindeBrowserClient = (
     organization: null,
     permissions: [],
     user: null,
-    userOrganizations: []
+    userOrganizations: null
   });
 
   useEffect(() => {

--- a/src/session/getUserOrganizations.ts
+++ b/src/session/getUserOrganizations.ts
@@ -20,13 +20,13 @@ export const getUserOrganizationsFactory =
         session,
         'x-hasura-org-codes',
         'id_token'
-      )) as string[];
+      )) as string[] ?? [];
 
       const hasuraOrganizations = (await kindeClient.getClaimValue(
         session,
         'x-hasura-organizations',
         'id_token'
-      )) as {id: string; name: string}[];
+      )) as {id: string; name: string}[] ?? [];
 
       return {
         orgCodes: [...userOrgs.orgCodes, ...hasuraOrgCodes],


### PR DESCRIPTION
# Explain your changes

When Hasura claims are not included in the token the resultant `null` claim causes `getUserOrganizations()` to return `null` due to an exception trying to spread the `null`.

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
