### PR TITLE
types: allow void for generic type

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -157,7 +157,7 @@ export type KindeUserBase = {
   phone_number?: string | null;
 };
 
-export interface KindeUser<T> extends KindeUserBase {
+export interface KindeUser<T = void> extends KindeUserBase {
   properties?: KindeUserProperties<T>;
 }
 


### PR DESCRIPTION
# Explain your changes
- allow KindeUser type to be used without a specified generic
_Suppose there is a related issue with enough detail for a reviewer to understand your changes fully. In that case, you can omit an explanation and instead include either “Fixes #XX” or “Updates #XX” where “XX” is the issue number._

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
