### PR TITLE
fix: get id token (await getSessionItem)

### DIFF
--- a/src/session/getIdToken.js
+++ b/src/session/getIdToken.js
@@ -18,7 +18,7 @@ import {jwtDecoder} from '@kinde/jwt-decoder';
 export const getIdTokenFactory = (req, res) => async () => {
   try {
     return jwtDecoder(
-      await sessionManager(req, res).getSessionItem('id_token')
+      await (await sessionManager(req, res)).getSessionItem('id_token')
     );
   } catch (err) {
     if (config.isDebugMode) {


### PR DESCRIPTION
# Explain your changes

- fix `getIdToken` bug where `getSessionItem` wasn't being awaited

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
