### PR TITLE
fix: ignore pre-fetch requests on auth routes

### DIFF
--- a/src/handlers/createOrg.ts
+++ b/src/handlers/createOrg.ts
@@ -16,5 +16,5 @@ export const createOrg = async (routerClient) => {
     options,
   );
 
-  return void routerClient.redirect(authUrl.toString());
+  return routerClient.redirect(authUrl.toString());
 };

--- a/src/handlers/login.ts
+++ b/src/handlers/login.ts
@@ -1,11 +1,16 @@
 import RouterClient from "../routerClients/RouterClient";
+import { isPreFetch } from "../utils/isPreFetch";
 
 /**
  *
  * @param {RouterClient} routerClient
  */
-export const register = async (routerClient) => {
-  const authUrl = await routerClient.kindeClient.register(
+export const login = async (routerClient: RouterClient) => {
+  if (isPreFetch(routerClient.req)) {
+    return null;
+  }
+  
+  const authUrl = await routerClient.kindeClient.login(
     routerClient.sessionManager,
     {
       authUrlParams: Object.fromEntries(routerClient.searchParams),
@@ -23,5 +28,5 @@ export const register = async (routerClient) => {
     );
   }
 
-  return void routerClient.redirect(authUrl.toString());
+  return routerClient.redirect(authUrl.toString());
 };

--- a/src/handlers/logout.ts
+++ b/src/handlers/logout.ts
@@ -8,7 +8,6 @@ import { isPreFetch } from "../utils/isPreFetch";
  */
 export const logout = async (routerClient: RouterClient) => {
   if (isPreFetch(routerClient.req)) {
-    console.log("isPreFetch");
     return null
   }
   

--- a/src/handlers/logout.ts
+++ b/src/handlers/logout.ts
@@ -1,11 +1,17 @@
 import { config } from "../config/index";
 import RouterClient from "../routerClients/RouterClient";
+import { isPreFetch } from "../utils/isPreFetch";
 
 /**
  *
  * @param {RouterClient} routerClient
  */
-export const logout = async (routerClient) => {
+export const logout = async (routerClient: RouterClient) => {
+  if (isPreFetch(routerClient.req)) {
+    console.log("isPreFetch");
+    return null
+  }
+  
   const authUrl = await routerClient.kindeClient.logout(
     routerClient.sessionManager,
   );
@@ -20,5 +26,5 @@ export const logout = async (routerClient) => {
     authUrl.searchParams.set("redirect", postLogoutRedirectURL);
   }
 
-  return void routerClient.redirect(authUrl.toString());
+  return routerClient.redirect(authUrl.toString());
 };

--- a/src/handlers/register.ts
+++ b/src/handlers/register.ts
@@ -1,11 +1,16 @@
 import RouterClient from "../routerClients/RouterClient";
+import { isPreFetch } from "../utils/isPreFetch";
 
 /**
  *
  * @param {RouterClient} routerClient
  */
-export const login = async (routerClient) => {
-  const authUrl = await routerClient.kindeClient.login(
+export const register = async (routerClient: RouterClient) => {
+  if (isPreFetch(routerClient.req)) {
+    return null
+  }
+  
+  const authUrl = await routerClient.kindeClient.register(
     routerClient.sessionManager,
     {
       authUrlParams: Object.fromEntries(routerClient.searchParams),
@@ -23,5 +28,5 @@ export const login = async (routerClient) => {
     );
   }
 
-  return void routerClient.redirect(authUrl.toString());
+  return routerClient.redirect(authUrl.toString());
 };

--- a/src/utils/isPreFetch.test.ts
+++ b/src/utils/isPreFetch.test.ts
@@ -1,0 +1,50 @@
+// isPrefetch.test.ts
+import { isPreFetch } from './isPreFetch';
+import { NextRequest } from 'next/server';
+import { describe, expect, it } from 'vitest';
+
+describe('isPreFetch', () => {
+  const mockNextRequest = (headers: Record<string, string>) => {
+    return {
+      headers: new Headers(headers)
+    } as NextRequest;
+  };
+
+  it('returns true when purpose header is prefetch', () => {
+    const req = mockNextRequest({ purpose: 'prefetch' });
+    expect(isPreFetch(req)).toBe(true);
+  });
+
+  it('returns true when x-purpose header is prefetch', () => {
+    const req = mockNextRequest({ 'x-purpose': 'prefetch' });
+    expect(isPreFetch(req)).toBe(true);
+  });
+
+  it('returns true when x-moz header is prefetch', () => {
+    const req = mockNextRequest({ 'x-moz': 'prefetch' });
+    expect(isPreFetch(req)).toBe(true);
+  });
+
+  it('returns false when no prefetch headers are present', () => {
+    const req = mockNextRequest({});
+    expect(isPreFetch(req)).toBe(false);
+  });
+
+  it('returns false when headers have different values', () => {
+    const req = mockNextRequest({ 
+      purpose: 'navigation',
+      'x-purpose': 'fetch',
+      'x-moz': 'load'
+    });
+    expect(isPreFetch(req)).toBe(false);
+  });
+
+  it('handles undefined request gracefully', () => {
+    expect(isPreFetch(undefined as unknown as NextRequest)).toBe(false);
+  });
+
+  it('handles null headers gracefully', () => {
+    const req = { headers: null } as unknown as NextRequest;
+    expect(isPreFetch(req)).toBe(false);
+  });
+});

--- a/src/utils/isPreFetch.ts
+++ b/src/utils/isPreFetch.ts
@@ -1,9 +1,9 @@
 import { NextRequest } from "next/server";
 
 export function isPreFetch(req: NextRequest): boolean {
-    const isPrefetch = req?.headers['purpose'] === 'prefetch' || 
-        req?.headers['x-purpose'] === 'prefetch' ||
-        req?.headers['x-moz'] === 'prefetch';
+    const isPrefetch = req?.headers && (req?.headers.get('purpose') === 'prefetch' || 
+        req?.headers.get('x-purpose') === 'prefetch' ||
+        req?.headers.get('x-moz') === 'prefetch');
 
     return !!isPrefetch;
 }

--- a/src/utils/isPreFetch.ts
+++ b/src/utils/isPreFetch.ts
@@ -1,0 +1,9 @@
+import { NextRequest } from "next/server";
+
+export function isPreFetch(req: NextRequest): boolean {
+    const isPrefetch = req?.headers['purpose'] === 'prefetch' || 
+        req?.headers['x-purpose'] === 'prefetch' ||
+        req?.headers['x-moz'] === 'prefetch';
+
+    return !!isPrefetch;
+}


### PR DESCRIPTION
# Explain your changes

Issue: When the auth routes are pre-fetched, this could cause unexpected behaviour. 

Fix: When a prefetch is noticed, ignore them.

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
