### PR TITLE
Allow locking down of postlogin redirect url

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -33,6 +33,9 @@ const SESSION_PREFIX = "pkce-verifier";
 
 const KINDE_SITE_URL = removeTrailingSlash(process.env.KINDE_SITE_URL);
 
+const KINDE_POST_LOGIN_ALLOWED_URL_REGEX =
+  process.env.KINDE_POST_LOGIN_ALLOWED_URL_REGEX;
+
 // We need to use NEXT_PUBLIC for frontend vars
 const KINDE_AUTH_API_PATH =
   removeTrailingSlash(process.env.NEXT_PUBLIC_KINDE_AUTH_API_PATH) ||
@@ -64,6 +67,7 @@ type Config = {
   SESSION_PREFIX: string;
   redirectURL: string;
   postLoginRedirectURL: string;
+  postLoginAllowedURLRegex: string;
   issuerURL: string;
   clientID: string;
   clientSecret: string;
@@ -102,6 +106,7 @@ export const config: Config = {
   SESSION_PREFIX,
   redirectURL: KINDE_SITE_URL,
   postLoginRedirectURL: KINDE_POST_LOGIN_REDIRECT_URL,
+  postLoginAllowedURLRegex: KINDE_POST_LOGIN_ALLOWED_URL_REGEX,
   issuerURL: KINDE_ISSUER_URL,
   clientID: KINDE_CLIENT_ID,
   clientSecret: KINDE_CLIENT_SECRET,

--- a/src/handlers/callback.ts
+++ b/src/handlers/callback.ts
@@ -39,7 +39,15 @@ export const callback = async (routerClient: RouterClient) => {
 
     return void routerClient.json({ error: error.message }, { status: 500 });
   }
-  if (postLoginRedirectURL) {
+
+  const isRedirectAllowed = (url: string) => {
+    if (!config.postLoginAllowedURLRegex) {
+      return true;
+    }
+    return new RegExp(config.postLoginAllowedURLRegex).test(url);
+  };
+
+  if (postLoginRedirectURL && isRedirectAllowed(postLoginRedirectURL)) {
     if (postLoginRedirectURL.startsWith("http")) {
       return void routerClient.redirect(postLoginRedirectURL);
     }


### PR DESCRIPTION
# Explain your changes

introduces a new environment variable `KINDE_POST_LOGIN_ALLOWED_URL_REGEX` which allows the founder to supply regex in order to restrict post login redirect URLs

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
