### PR TITLE
2.5.0 - Next 13 compatibility

### DIFF
--- a/src/authMiddleware/authMiddleware.ts
+++ b/src/authMiddleware/authMiddleware.ts
@@ -16,6 +16,12 @@ const handleMiddleware = async (req, options, onSuccess) => {
 
   const isReturnToCurrentPage = options?.isReturnToCurrentPage;
   const loginPage = options?.loginPage || "/api/auth/login";
+  const callbackPage = "/api/auth/kinde_callback";
+  const registerPage = "/api/auth/register";
+
+  if(loginPage == pathname || callbackPage == pathname || registerPage == pathname) {
+    return NextResponse.next();
+  }
 
   let publicPaths = ["/_next", "/favicon.ico"];
   if (options?.publicPaths !== undefined) {
@@ -28,7 +34,7 @@ const handleMiddleware = async (req, options, onSuccess) => {
     ? `${loginPage}?post_login_redirect_url=${pathname}`
     : loginPage;
 
-  const isPublicPath = loginPage == pathname || publicPaths.some((p) => pathname.startsWith(p));
+  const isPublicPath = publicPaths.some((p) => pathname.startsWith(p));
 
   // getAccessToken will validate the token
   let kindeAccessToken = await getAccessToken(req);

--- a/src/handlers/login.ts
+++ b/src/handlers/login.ts
@@ -1,3 +1,4 @@
+import { headers } from "next/headers";
 import RouterClient from "../routerClients/RouterClient";
 import { isPreFetch } from "../utils/isPreFetch";
 
@@ -6,7 +7,8 @@ import { isPreFetch } from "../utils/isPreFetch";
  * @param {RouterClient} routerClient
  */
 export const login = async (routerClient: RouterClient) => {
-  if (isPreFetch(routerClient.req)) {
+  const heads = await headers();
+  if (isPreFetch(heads)) {
     return null;
   }
   

--- a/src/handlers/logout.ts
+++ b/src/handlers/logout.ts
@@ -1,3 +1,4 @@
+import { headers } from "next/headers";
 import { config } from "../config/index";
 import RouterClient from "../routerClients/RouterClient";
 import { isPreFetch } from "../utils/isPreFetch";
@@ -7,7 +8,8 @@ import { isPreFetch } from "../utils/isPreFetch";
  * @param {RouterClient} routerClient
  */
 export const logout = async (routerClient: RouterClient) => {
-  if (isPreFetch(routerClient.req)) {
+  const heads = await headers();
+  if (isPreFetch(heads)) {
     return null
   }
   

--- a/src/handlers/register.ts
+++ b/src/handlers/register.ts
@@ -1,3 +1,4 @@
+import { headers } from "next/headers";
 import RouterClient from "../routerClients/RouterClient";
 import { isPreFetch } from "../utils/isPreFetch";
 
@@ -6,7 +7,8 @@ import { isPreFetch } from "../utils/isPreFetch";
  * @param {RouterClient} routerClient
  */
 export const register = async (routerClient: RouterClient) => {
-  if (isPreFetch(routerClient.req)) {
+  const heads = await headers();
+  if (isPreFetch(heads)) {
     return null
   }
   

--- a/src/utils/isPreFetch.test.ts
+++ b/src/utils/isPreFetch.test.ts
@@ -1,50 +1,40 @@
 // isPrefetch.test.ts
+import { ReadonlyHeaders } from 'next/dist/server/web/spec-extension/adapters/headers';
 import { isPreFetch } from './isPreFetch';
 import { NextRequest } from 'next/server';
 import { describe, expect, it } from 'vitest';
 
 describe('isPreFetch', () => {
-  const mockNextRequest = (headers: Record<string, string>) => {
-    return {
-      headers: new Headers(headers)
-    } as NextRequest;
+  const mockHeaders = (headers: Record<string, string>) => {
+    return new Headers(headers) as ReadonlyHeaders
   };
 
   it('returns true when purpose header is prefetch', () => {
-    const req = mockNextRequest({ purpose: 'prefetch' });
-    expect(isPreFetch(req)).toBe(true);
+    const headers = mockHeaders({ purpose: 'prefetch' });
+    expect(isPreFetch(headers)).toBe(true);
   });
 
   it('returns true when x-purpose header is prefetch', () => {
-    const req = mockNextRequest({ 'x-purpose': 'prefetch' });
-    expect(isPreFetch(req)).toBe(true);
+    const headers = mockHeaders({ 'x-purpose': 'prefetch' });
+    expect(isPreFetch(headers)).toBe(true);
   });
 
   it('returns true when x-moz header is prefetch', () => {
-    const req = mockNextRequest({ 'x-moz': 'prefetch' });
-    expect(isPreFetch(req)).toBe(true);
+    const headers = mockHeaders({ 'x-moz': 'prefetch' });
+    expect(isPreFetch(headers)).toBe(true);
   });
 
   it('returns false when no prefetch headers are present', () => {
-    const req = mockNextRequest({});
-    expect(isPreFetch(req)).toBe(false);
+    const headers = mockHeaders({});
+    expect(isPreFetch(headers)).toBe(false);
   });
 
   it('returns false when headers have different values', () => {
-    const req = mockNextRequest({ 
+    const headers = mockHeaders({ 
       purpose: 'navigation',
       'x-purpose': 'fetch',
       'x-moz': 'load'
     });
-    expect(isPreFetch(req)).toBe(false);
-  });
-
-  it('handles undefined request gracefully', () => {
-    expect(isPreFetch(undefined as unknown as NextRequest)).toBe(false);
-  });
-
-  it('handles null headers gracefully', () => {
-    const req = { headers: null } as unknown as NextRequest;
-    expect(isPreFetch(req)).toBe(false);
+    expect(isPreFetch(headers)).toBe(false);
   });
 });

--- a/src/utils/isPreFetch.ts
+++ b/src/utils/isPreFetch.ts
@@ -1,9 +1,9 @@
-import { NextRequest } from "next/server";
+import { ReadonlyHeaders } from "next/dist/server/web/spec-extension/adapters/headers";
 
-export function isPreFetch(req: NextRequest): boolean {
-    const isPrefetch = req?.headers && (req?.headers.get('purpose') === 'prefetch' || 
-        req?.headers.get('x-purpose') === 'prefetch' ||
-        req?.headers.get('x-moz') === 'prefetch');
+export function isPreFetch(headers: ReadonlyHeaders): boolean {
+    const isPrefetch = headers.get('purpose') === 'prefetch' || 
+        headers.get('x-purpose') === 'prefetch' ||
+        headers.get('x-moz') === 'prefetch';
 
     return !!isPrefetch;
 }


### PR DESCRIPTION
# Explain your changes

This PR contains some minor fixes for the upcoming 2.5.0 release to improve compatibility with Next 13.
- The bailout for internal Kinde paths (like `login`) has been moved to the very top of the middleware. It has also been expanded to include other paths like `kinde_callback` and `register`. This was the source of a redirect loop in Next 13.
- The prefetch check for `login`, `logout` and `register` links has been reworked to use the `headers()` function instead of directly accessing headers on a `NextRequest` object. In Next 13, the `headers` on a `NextRequest` are an object, but in 14 onwards they're a map. The existing logic treated it like a map and thus caused breakages in Next 13 (`TypeError: e.headers.get is not a function`). Instead, the prefetch check now expects the result of `headers()` as it's a stable and consistent API for working with headers in all versions of Next from 13 on.

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
