### PR TITLE
fix static generation issue

### DIFF
--- a/src/session/index.ts
+++ b/src/session/index.ts
@@ -21,6 +21,7 @@ import { NextApiRequest, NextApiResponse } from "next";
 import { connection } from "next/server";
 
 export default async function (req?: NextApiRequest, res?: NextApiResponse) {
+  // This will prevent NextJS generating a static page where this function is called if no other Dynamic APIs are used.
   await connection();
   return {
     refreshTokens: async () => {

--- a/src/session/index.ts
+++ b/src/session/index.ts
@@ -18,10 +18,10 @@ import { getRolesFactory } from "./getRoles";
 import { getClaimFactory } from "./getClaim";
 import { config } from "../config/index";
 import { NextApiRequest, NextApiResponse } from "next";
-import { headers } from "next/headers";
+import { connection } from "next/server";
 
 export default async function (req?: NextApiRequest, res?: NextApiResponse) {
-  await headers();
+  await connection();
   return {
     refreshTokens: async () => {
       try {

--- a/src/session/index.ts
+++ b/src/session/index.ts
@@ -18,8 +18,10 @@ import { getRolesFactory } from "./getRoles";
 import { getClaimFactory } from "./getClaim";
 import { config } from "../config/index";
 import { NextApiRequest, NextApiResponse } from "next";
+import { headers } from "next/headers";
 
-export default function (req?: NextApiRequest, res?: NextApiResponse) {
+export default async function (req?: NextApiRequest, res?: NextApiResponse) {
+  await headers();
   return {
     refreshTokens: async () => {
       try {
@@ -28,11 +30,10 @@ export default function (req?: NextApiRequest, res?: NextApiResponse) {
         // but it won't work.
         // Maybe we should provide user feedback on this?
         const response = await kindeClient.refreshTokens(
-          await sessionManager(req, res),
+          await sessionManager(req, res)
         );
         return response;
       } catch (error) {
-        
         if (config.isDebugMode) {
           console.error(error);
         }


### PR DESCRIPTION
addressing issue #261 

I had a hard time building the playground so I couldn't test building. also if it's not obvious this would be a breaking change because every call of `getKindeServerSession` would need to be switched to await  

I chose headers but it can be accomplished with multiple different functions for more info https://nextjs.org/docs/app/building-your-application/rendering/server-components#dynamic-apis

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
