### PR TITLE
fix: pages router compat for prefetch header checks

### DIFF
--- a/src/handlers/login.ts
+++ b/src/handlers/login.ts
@@ -1,14 +1,14 @@
-import { headers } from "next/headers";
 import RouterClient from "../routerClients/RouterClient";
 import { isPreFetch } from "../utils/isPreFetch";
+import { getHeaders } from "../utils/getHeaders";
 
 /**
  *
  * @param {RouterClient} routerClient
  */
 export const login = async (routerClient: RouterClient) => {
-  const heads = await headers();
-  if (isPreFetch(heads)) {
+  const headers = await getHeaders(routerClient.req);
+  if (isPreFetch(headers)) {
     return null;
   }
   

--- a/src/handlers/logout.ts
+++ b/src/handlers/logout.ts
@@ -1,15 +1,15 @@
-import { headers } from "next/headers";
 import { config } from "../config/index";
 import RouterClient from "../routerClients/RouterClient";
 import { isPreFetch } from "../utils/isPreFetch";
+import { getHeaders } from "../utils/getHeaders";
 
 /**
  *
  * @param {RouterClient} routerClient
  */
 export const logout = async (routerClient: RouterClient) => {
-  const heads = await headers();
-  if (isPreFetch(heads)) {
+  const headers = await getHeaders(routerClient.req);
+  if (isPreFetch(headers)) {
     return null
   }
   

--- a/src/handlers/register.ts
+++ b/src/handlers/register.ts
@@ -1,5 +1,5 @@
-import { headers } from "next/headers";
 import RouterClient from "../routerClients/RouterClient";
+import { getHeaders } from "../utils/getHeaders";
 import { isPreFetch } from "../utils/isPreFetch";
 
 /**
@@ -7,8 +7,8 @@ import { isPreFetch } from "../utils/isPreFetch";
  * @param {RouterClient} routerClient
  */
 export const register = async (routerClient: RouterClient) => {
-  const heads = await headers();
-  if (isPreFetch(heads)) {
+  const headers = await getHeaders(routerClient.req);
+  if (isPreFetch(headers)) {
     return null
   }
   

--- a/src/utils/getHeaders.test.ts
+++ b/src/utils/getHeaders.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { getHeaders } from './getHeaders'
+import { NextRequest } from 'next/server'
+import { NextApiRequest } from 'next'
+
+// Default mock for next/headers
+const defaultHeadersMock = vi.fn(() => new Headers({ 'x-test': 'test-value' }))
+
+vi.mock('next/headers', () => ({
+  headers: defaultHeadersMock
+}))
+
+describe('getHeaders', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    // Reset the mock implementation to default before each test
+    defaultHeadersMock.mockImplementation(() => new Headers({ 'x-test': 'test-value' }))
+  })
+
+  it('should handle Pages Router request (NextApiRequest)', async () => {
+    const mockReq = {
+      headers: {
+        'x-test': 'test-value'
+      }
+    } as unknown as NextApiRequest
+
+    const result = await getHeaders(mockReq)
+    expect(result instanceof Headers).toBe(true)
+    expect(result.get('x-test')).toBe('test-value')
+  })
+
+  it('should handle App Router request (NextRequest)', async () => {
+    const mockReq = new NextRequest('https://example.com', {
+      headers: {
+        'x-test': 'test-value'
+      }
+    })
+
+    const result = await getHeaders(mockReq)
+    expect(result instanceof Headers).toBe(true)
+    expect(result.get('x-test')).toBe('test-value')
+  })
+
+  it('should handle App Router environment with no request', async () => {
+    const result = await getHeaders()
+    expect(result instanceof Headers).toBe(true)
+    expect(result.get('x-test')).toBe('test-value')
+  })
+
+  it('should throw error when headers import fails', async () => {
+    // Override the mock implementation for this test only
+    defaultHeadersMock.mockImplementation(() => {
+      throw new Error('Import failed')
+    })
+
+    await expect(getHeaders()).rejects.toThrow('Kinde: Failed to read request headers')
+  })
+})

--- a/src/utils/getHeaders.ts
+++ b/src/utils/getHeaders.ts
@@ -1,0 +1,19 @@
+import { NextApiRequest } from "next";
+import { ReadonlyHeaders } from "next/dist/server/web/spec-extension/adapters/headers";
+import { NextRequest } from "next/server";
+
+export const getHeaders = async (req?: NextRequest | NextApiRequest) => {
+    if(req) {
+        // pages router, or we've provided a request down on app router for some reason
+        return new Headers(req.headers as HeadersInit)
+    } else {
+        try { 
+            // dynamically import headers on app router environments in Next >=13 (it didn't exist prior to 13)
+            const { headers } = await import('next/headers')
+            const heads = await headers()
+            return heads
+        } catch (error) {
+            throw new Error(`Kinde: Failed to read request headers (are you using a Next.js version prior to 13?)`)
+        }
+    }
+};

--- a/src/utils/isPreFetch.test.ts
+++ b/src/utils/isPreFetch.test.ts
@@ -1,40 +1,41 @@
-// isPrefetch.test.ts
-import { ReadonlyHeaders } from 'next/dist/server/web/spec-extension/adapters/headers';
-import { isPreFetch } from './isPreFetch';
-import { NextRequest } from 'next/server';
-import { describe, expect, it } from 'vitest';
+import { describe, it, expect } from 'vitest'
+import { isPreFetch } from './isPreFetch'
 
 describe('isPreFetch', () => {
-  const mockHeaders = (headers: Record<string, string>) => {
-    return new Headers(headers) as ReadonlyHeaders
-  };
+  it('should return true when purpose header is prefetch', () => {
+    const headers = new Headers({
+      purpose: 'prefetch'
+    })
+    expect(isPreFetch(headers)).toBe(true)
+  })
 
-  it('returns true when purpose header is prefetch', () => {
-    const headers = mockHeaders({ purpose: 'prefetch' });
-    expect(isPreFetch(headers)).toBe(true);
-  });
+  it('should return true when x-purpose header is prefetch', () => {
+    const headers = new Headers({
+      'x-purpose': 'prefetch'
+    })
+    expect(isPreFetch(headers)).toBe(true)
+  })
 
-  it('returns true when x-purpose header is prefetch', () => {
-    const headers = mockHeaders({ 'x-purpose': 'prefetch' });
-    expect(isPreFetch(headers)).toBe(true);
-  });
+  it('should return true when x-moz header is prefetch', () => {
+    const headers = new Headers({
+      'x-moz': 'prefetch'
+    })
+    expect(isPreFetch(headers)).toBe(true)
+  })
 
-  it('returns true when x-moz header is prefetch', () => {
-    const headers = mockHeaders({ 'x-moz': 'prefetch' });
-    expect(isPreFetch(headers)).toBe(true);
-  });
+  it('should return false when no prefetch headers are present', () => {
+    const headers = new Headers({
+      'content-type': 'application/json'
+    })
+    expect(isPreFetch(headers)).toBe(false)
+  })
 
-  it('returns false when no prefetch headers are present', () => {
-    const headers = mockHeaders({});
-    expect(isPreFetch(headers)).toBe(false);
-  });
-
-  it('returns false when headers have different values', () => {
-    const headers = mockHeaders({ 
+  it('should return false when headers have different values', () => {
+    const headers = new Headers({
       purpose: 'navigation',
       'x-purpose': 'fetch',
-      'x-moz': 'load'
-    });
-    expect(isPreFetch(headers)).toBe(false);
-  });
-});
+      'x-moz': 'reload'
+    })
+    expect(isPreFetch(headers)).toBe(false)
+  })
+})

--- a/src/utils/isPreFetch.ts
+++ b/src/utils/isPreFetch.ts
@@ -1,6 +1,5 @@
-import { ReadonlyHeaders } from "next/dist/server/web/spec-extension/adapters/headers";
 
-export function isPreFetch(headers: ReadonlyHeaders): boolean {
+export function isPreFetch(headers: Headers): boolean {
     const isPrefetch = headers.get('purpose') === 'prefetch' || 
         headers.get('x-purpose') === 'prefetch' ||
         headers.get('x-moz') === 'prefetch';


### PR DESCRIPTION
# Explain your changes

#257 was necessary to better add compatibility between different Next.js versions in the app router, but inadvertently broke the pages router.

I've introduced a new utility function called `getHeaders` for retrieving headers based on router/next version, with the following flow:
- If a request is passed down (pages router, or app router if we've passed down the request for some reason), return the request headers
- If no request is passed down (app router), dynamically import next/headers and return the awaited headers.

### Why dynamic import?

To get error feedback for versions prior to Next 13, where the headers utility did not exist. Next 12 is *very* outdated at this stage regardless.

The `login`, `logout` and `register` route flows have been updated to use this new utility method and pass the results to `isPreFetch`. 

The `isPreFetch` tests have been re-written, and I have introduced tests for the new `getHeaders` utility method.

Note: I've been able to successfully use this in a barebones pages router repo and fix the original issue (`headers() was called outside a request scope`), but getting some real-world feedback on whether this has fixed other peoples issues or not would be very valuable.

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
