### PR TITLE
fix: improve logic for handling index paths in publicPaths

### DIFF
--- a/src/authMiddleware/authMiddleware.ts
+++ b/src/authMiddleware/authMiddleware.ts
@@ -1,210 +1,209 @@
-import { NextResponse } from "next/server";
-import { config } from "../config/index";
-import { KindeAccessToken, KindeIdToken } from "../../types";
-import { jwtDecoder } from "@kinde/jwt-decoder";
-import { isTokenExpired } from "../utils/jwt/validation";
-import { getAccessToken } from "../utils/getAccessToken";
-import { kindeClient } from "../session/kindeServerClient";
-import { sessionManager } from "../session/sessionManager";
-import { getSplitCookies } from "../utils/cookies/getSplitSerializedCookies";
-import { getIdToken } from "../utils/getIdToken";
-import { OAuth2CodeExchangeResponse } from "@kinde-oss/kinde-typescript-sdk";
-import { copyCookiesToRequest } from "../utils/copyCookiesToRequest";
-import { routes
- } from "../config/index";
+import { NextResponse } from 'next/server';
+import { config } from '../config/index';
+import { KindeAccessToken, KindeIdToken } from '../../types';
+import { jwtDecoder } from '@kinde/jwt-decoder';
+import { isTokenExpired } from '../utils/jwt/validation';
+import { getAccessToken } from '../utils/getAccessToken';
+import { kindeClient } from '../session/kindeServerClient';
+import { sessionManager } from '../session/sessionManager';
+import { getSplitCookies } from '../utils/cookies/getSplitSerializedCookies';
+import { getIdToken } from '../utils/getIdToken';
+import { OAuth2CodeExchangeResponse } from '@kinde-oss/kinde-typescript-sdk';
+import { copyCookiesToRequest } from '../utils/copyCookiesToRequest';
+import { routes } from '../config/index';
+
 const handleMiddleware = async (req, options, onSuccess) => {
-  const { pathname } = req.nextUrl;
+	const { pathname } = req.nextUrl;
 
-  const isReturnToCurrentPage = options?.isReturnToCurrentPage;
-  const loginPage = options?.loginPage || `/api/auth/${routes.login}`;
-  const callbackPage = `/api/auth/kinde_callback`;
-  const registerPage = `/api/auth/${routes.register}`;
+	const isReturnToCurrentPage = options?.isReturnToCurrentPage;
+	const loginPage = options?.loginPage || `/api/auth/${routes.login}`;
+	const callbackPage = `/api/auth/kinde_callback`;
+	const registerPage = `/api/auth/${routes.register}`;
 
-  if(loginPage == pathname || callbackPage == pathname || registerPage == pathname) {
-    return NextResponse.next();
-  }
+	if (loginPage == pathname || callbackPage == pathname || registerPage == pathname) {
+		return NextResponse.next();
+	}
 
-  let publicPaths = ["/_next", "/favicon.ico"];
-  if (options?.publicPaths !== undefined) {
-    if (Array.isArray(options?.publicPaths)) {
-      publicPaths = options.publicPaths;
-    }
-  }
+	let publicPaths = ['/_next', '/favicon.ico'];
+	if (options?.publicPaths !== undefined) {
+		if (Array.isArray(options?.publicPaths)) {
+			publicPaths = options.publicPaths;
+		}
+	}
 
-  const loginRedirectUrl = isReturnToCurrentPage
-    ? `${loginPage}?post_login_redirect_url=${pathname}`
-    : loginPage;
+	const loginRedirectUrl = isReturnToCurrentPage
+		? `${loginPage}?post_login_redirect_url=${pathname}`
+		: loginPage;
 
-  const isPublicPath = publicPaths.some((p) => {
-    // explicit root path handling
-    // if we use startsWith and "/" is provided as a publicPath,
-    // we inadvertently match all paths because they all start with "/"
-    if(p === "/") return pathname === "/";
-    return pathname.startsWith(p);
-  });
+	const isPublicPath = publicPaths.some((p) => {
+		// explicit root path handling
+		// if we use startsWith and "/" is provided as a publicPath,
+		// we inadvertently match all paths because they all start with "/"
+		if (p === '/') return pathname === '/';
+		return pathname.startsWith(p);
+	});
 
-  // getAccessToken will validate the token
-  let kindeAccessToken = await getAccessToken(req);
-  // getIdToken will validate the token
-  let kindeIdToken = await getIdToken(req);
+	// getAccessToken will validate the token
+	let kindeAccessToken = await getAccessToken(req);
+	// getIdToken will validate the token
+	let kindeIdToken = await getIdToken(req);
 
+	// if no access token, redirect to login
+	if ((!kindeAccessToken || !kindeIdToken) && !isPublicPath) {
+		if (config.isDebugMode) {
+			console.log('authMiddleware: no access or id token, redirecting to login');
+		}
+		return NextResponse.redirect(
+			new URL(loginRedirectUrl, options?.redirectURLBase || config.redirectURL)
+		);
+	}
 
-  // if no access token, redirect to login
-  if ((!kindeAccessToken || !kindeIdToken) && !isPublicPath) {
-    if(config.isDebugMode) {
-      console.log('authMiddleware: no access or id token, redirecting to login')
-    }
-    return NextResponse.redirect(
-      new URL(loginRedirectUrl, options?.redirectURLBase || config.redirectURL),
-    );
-  }
+	const session = await sessionManager(req);
+	let refreshResponse: OAuth2CodeExchangeResponse | null = null;
+	const resp = NextResponse.next();
 
-  const session = await sessionManager(req)
-  let refreshResponse: OAuth2CodeExchangeResponse | null = null
-  const resp = NextResponse.next();
+	// if accessToken is expired, refresh it
+	if (isTokenExpired(kindeAccessToken) || isTokenExpired(kindeIdToken)) {
+		if (config.isDebugMode) {
+			console.log('authMiddleware: access token expired, refreshing');
+		}
 
-  // if accessToken is expired, refresh it
-  if(isTokenExpired(kindeAccessToken) || isTokenExpired(kindeIdToken)) {
-    if(config.isDebugMode) {
-      console.log('authMiddleware: access token expired, refreshing')
-    }
+		try {
+			refreshResponse = await kindeClient.refreshTokens(session);
+			kindeAccessToken = refreshResponse.access_token;
+			kindeIdToken = refreshResponse.id_token;
 
-    try {
-      refreshResponse = await kindeClient.refreshTokens(session);
-      kindeAccessToken = refreshResponse.access_token
-      kindeIdToken = refreshResponse.id_token
+			// if we want layouts/pages to get immediate access to the new token,
+			// we need to set the cookie on the response here
+			const splitAccessTokenCookies = getSplitCookies('access_token', refreshResponse.access_token);
+			splitAccessTokenCookies.forEach((cookie) => {
+				resp.cookies.set(cookie.name, cookie.value, cookie.options);
+			});
 
-      // if we want layouts/pages to get immediate access to the new token,
-      // we need to set the cookie on the response here
-      const splitAccessTokenCookies = getSplitCookies("access_token", refreshResponse.access_token)
-      splitAccessTokenCookies.forEach((cookie) => {
-        resp.cookies.set(cookie.name, cookie.value, cookie.options);
-      })
+			const splitIdTokenCookies = getSplitCookies('id_token', refreshResponse.id_token);
+			splitIdTokenCookies.forEach((cookie) => {
+				resp.cookies.set(cookie.name, cookie.value, cookie.options);
+			});
 
-      const splitIdTokenCookies = getSplitCookies("id_token", refreshResponse.id_token)
-      splitIdTokenCookies.forEach((cookie) => {
-        resp.cookies.set(cookie.name, cookie.value, cookie.options);
-      })
+			// copy the cookies from the response to the request
+			// in Next versions prior to 14.2.8, the cookies function
+			// reads the Set-Cookie header from the *request* object, not the *response* object
+			// in order to get the new cookies to the request, we need to copy them over
+			copyCookiesToRequest(req, resp);
 
-      // copy the cookies from the response to the request
-      // in Next versions prior to 14.2.8, the cookies function
-      // reads the Set-Cookie header from the *request* object, not the *response* object
-      // in order to get the new cookies to the request, we need to copy them over
-      copyCookiesToRequest(req, resp)
+			if (config.isDebugMode) {
+				console.log('authMiddleware: tokens refreshed');
+			}
+		} catch (error) {
+			// token is expired and refresh failed, redirect to login
+			if (config.isDebugMode) {
+				console.error('authMiddleware: token refresh failed, redirecting to login');
+			}
 
-      if(config.isDebugMode) {
-        console.log('authMiddleware: tokens refreshed')
-      }
-    } catch(error) {
-      // token is expired and refresh failed, redirect to login
-      if(config.isDebugMode) {
-        console.error('authMiddleware: token refresh failed, redirecting to login')
-      }
+			if (!isPublicPath) {
+				return NextResponse.redirect(
+					new URL(loginRedirectUrl, options?.redirectURLBase || config.redirectURL)
+				);
+			}
+		}
+	}
 
-      if(!isPublicPath) {
-        return NextResponse.redirect(
-          new URL(loginRedirectUrl, options?.redirectURLBase || config.redirectURL),
-        );
-      }
-    }
-  }
+	// we don't bail out earlier than here because we want to refresh the tokens
+	// if they are expired, even if the path is public
+	if (isPublicPath) {
+		return resp;
+	}
 
-  // we don't bail out earlier than here because we want to refresh the tokens
-  // if they are expired, even if the path is public
-  if(isPublicPath) {
-    return resp;
-  }
+	let accessTokenValue: KindeAccessToken | null = null;
+	let idTokenValue: KindeIdToken | null = null;
 
-  let accessTokenValue: KindeAccessToken | null = null
-  let idTokenValue: KindeIdToken | null = null
+	try {
+		accessTokenValue = jwtDecoder<KindeAccessToken>(kindeAccessToken);
+	} catch (error) {
+		if (config.isDebugMode) {
+			console.error('authMiddleware: access token decode failed, redirecting to login');
+		}
+		return NextResponse.redirect(
+			new URL(loginRedirectUrl, options?.redirectURLBase || config.redirectURL)
+		);
+	}
 
-  try {
-    accessTokenValue = jwtDecoder<KindeAccessToken>(
-      kindeAccessToken,
-    );
-  } catch(error) {
-    if(config.isDebugMode) {
-      console.error('authMiddleware: access token decode failed, redirecting to login')
-    }
-    return NextResponse.redirect(
-      new URL(loginRedirectUrl, options?.redirectURLBase || config.redirectURL),
-    );
-  }
+	try {
+		idTokenValue = jwtDecoder<KindeIdToken>(kindeIdToken);
+	} catch (error) {
+		if (config.isDebugMode) {
+			console.error('authMiddleware: id token decode failed, redirecting to login');
+		}
+		return NextResponse.redirect(
+			new URL(loginRedirectUrl, options?.redirectURLBase || config.redirectURL)
+		);
+	}
 
-  try {
-    idTokenValue = jwtDecoder<KindeIdToken>(
-      kindeIdToken,
-    );
-  } catch(error) {
-    if(config.isDebugMode) {
-      console.error('authMiddleware: id token decode failed, redirecting to login')
-    }
-    return NextResponse.redirect(
-      new URL(loginRedirectUrl, options?.redirectURLBase || config.redirectURL),
-    );
-  }
+	const customValidationValid = options?.isAuthorized
+		? options.isAuthorized({ req, token: accessTokenValue })
+		: true;
 
-  const customValidationValid = options?.isAuthorized
-    ? options.isAuthorized({ req, token: accessTokenValue })
-    : true;
+	if (customValidationValid && onSuccess) {
+		if (config.isDebugMode) {
+			console.log('authMiddleware: invoking onSuccess callback');
+		}
+		const callbackResult = await onSuccess({
+			token: accessTokenValue,
+			user: {
+				family_name: idTokenValue.family_name,
+				given_name: idTokenValue.given_name,
+				email: idTokenValue.email,
+				id: idTokenValue.sub,
+				picture: idTokenValue.picture,
+			},
+		});
 
-  if (customValidationValid && onSuccess) {
-    if(config.isDebugMode) {
-      console.log('authMiddleware: invoking onSuccess callback')
-    }
-    const callbackResult = await onSuccess({
-      token: accessTokenValue,
-      user: {
-        family_name: idTokenValue.family_name,
-        given_name: idTokenValue.given_name,
-        email: idTokenValue.email,
-        id: idTokenValue.sub,
-        picture: idTokenValue.picture,
-      },
-    });
+		// If a user returned a response from their onSuccess callback, copy our refreshed tokens to it
+		if (callbackResult instanceof NextResponse) {
+			if (config.isDebugMode) {
+				console.log(
+					'authMiddleware: onSuccess callback returned a response, copying our cookies to it'
+				);
+			}
+			// Copy our cookies to their response
+			resp.cookies.getAll().forEach((cookie) => {
+				callbackResult.cookies.set(cookie.name, cookie.value, {
+					...cookie,
+				});
+			});
 
-    // If a user returned a response from their onSuccess callback, copy our refreshed tokens to it
-    if (callbackResult instanceof NextResponse) {
-        if(config.isDebugMode) {
-          console.log('authMiddleware: onSuccess callback returned a response, copying our cookies to it')
-        }
-        // Copy our cookies to their response
-        resp.cookies.getAll().forEach(cookie => {
-            callbackResult.cookies.set(cookie.name, cookie.value, {
-              ...cookie
-            });
-        });
+			// Copy any headers we set (if any) to their response
+			resp.headers.forEach((value, key) => {
+				callbackResult.headers.set(key, value);
+			});
 
-        // Copy any headers we set (if any) to their response
-        resp.headers.forEach((value, key) => {
-            callbackResult.headers.set(key, value);
-        });
+			return callbackResult;
+		}
 
-        return callbackResult;
-    }
+		// If they didn't return a response, return our response with the refreshed tokens
+		if (config.isDebugMode) {
+			console.log(
+				'authMiddleware: onSuccess callback did not return a response, returning our response'
+			);
+		}
 
-    // If they didn't return a response, return our response with the refreshed tokens
-    if(config.isDebugMode) {
-      console.log('authMiddleware: onSuccess callback did not return a response, returning our response')
-    }
+		return resp;
+	}
 
-    return resp;
-  }
+	if (customValidationValid) {
+		if (config.isDebugMode) {
+			console.log('authMiddleware: customValidationValid is true, returning response');
+		}
+		return resp;
+	}
 
-  if (customValidationValid) {
-    if(config.isDebugMode) {
-      console.log('authMiddleware: customValidationValid is true, returning response')
-    }
-    return resp;
-  }
+	if (config.isDebugMode) {
+		console.log('authMiddleware: default behaviour, redirecting to login');
+	}
 
-  if(config.isDebugMode) {
-    console.log('authMiddleware: default behaviour, redirecting to login')
-  }
-
-  return NextResponse.redirect(
-    new URL(loginRedirectUrl, options?.redirectURLBase || config.redirectURL),
-  );
+	return NextResponse.redirect(
+		new URL(loginRedirectUrl, options?.redirectURLBase || config.redirectURL)
+	);
 };
 
 /**
@@ -212,25 +211,25 @@ const handleMiddleware = async (req, options, onSuccess) => {
  * @param {function(req: Request & {kindeAuth: {user: any, token: string}})} [onIsAuthorized]
  */
 export function withAuth(...args) {
-  // most basic usage - no options
-  if (!args.length || args[0] instanceof Request) {
-    // @ts-ignore
-    return handleMiddleware(...args);
-  }
+	// most basic usage - no options
+	if (!args.length || args[0] instanceof Request) {
+		// @ts-ignore
+		return handleMiddleware(...args);
+	}
 
-  // passing through the kindeAuth data to the middleware function
-  if (typeof args[0] === "function") {
-    const middleware = args[0];
-    const options = args[1];
-    return async (...args) =>
-      await handleMiddleware(args[0], options, async ({ token, user }) => {
-        args[0].kindeAuth = { token, user };
-        return await middleware(...args);
-      });
-  }
+	// passing through the kindeAuth data to the middleware function
+	if (typeof args[0] === 'function') {
+		const middleware = args[0];
+		const options = args[1];
+		return async (...args) =>
+			await handleMiddleware(args[0], options, async ({ token, user }) => {
+				args[0].kindeAuth = { token, user };
+				return await middleware(...args);
+			});
+	}
 
-  // includes options
-  const options = args[0];
-  // @ts-ignore
-  return async (...args) => await handleMiddleware(args[0], options);
+	// includes options
+	const options = args[0];
+	// @ts-ignore
+	return async (...args) => await handleMiddleware(args[0], options);
 }

--- a/src/authMiddleware/authMiddleware.ts
+++ b/src/authMiddleware/authMiddleware.ts
@@ -11,7 +11,6 @@ import { getIdToken } from "../utils/getIdToken";
 import { OAuth2CodeExchangeResponse } from "@kinde-oss/kinde-typescript-sdk";
 import { copyCookiesToRequest } from "../utils/copyCookiesToRequest";
 import { routes
-  
  } from "../config/index";
 const handleMiddleware = async (req, options, onSuccess) => {
   const { pathname } = req.nextUrl;
@@ -36,7 +35,13 @@ const handleMiddleware = async (req, options, onSuccess) => {
     ? `${loginPage}?post_login_redirect_url=${pathname}`
     : loginPage;
 
-  const isPublicPath = publicPaths.some((p) => pathname.startsWith(p));
+  const isPublicPath = publicPaths.some((p) => {
+    // explicit root path handling
+    // if we use startsWith and "/" is provided as a publicPath,
+    // we inadvertently match all paths because they all start with "/"
+    if(p === "/") return pathname === "/";
+    return pathname.startsWith(p);
+  });
 
   // getAccessToken will validate the token
   let kindeAccessToken = await getAccessToken(req);


### PR DESCRIPTION
# Explain your changes

Technically this bug has always existed, but is only now being brought to light because the new middleware is protect-all by default.

We use `startsWith` to compare `publicPaths` in the middleware. If a user provided `"/"` as a public path option, it would inadvertently make *all* paths public as all paths start with `"/"`

We have explicit handling for `"/"` public paths now.

### Thoughts

Should we be using `startsWith` at all? Let's think of a scenario where a user provides `"/blog"` as a public path. This means that *any* route under `"/blog"` is now considered public. What if there's something a user wants protected under this path, like `"/blog/admin"`? Should we be using explicit comparisons? Allow the user to supply wildcards? Food for thought.

The above could be considered a breaking change though as it changes how we define what a public path is.

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
