### PR TITLE
fix: rework setup route handler

### DIFF
--- a/src/frontend/KindeBrowserClient.ts
+++ b/src/frontend/KindeBrowserClient.ts
@@ -1,248 +1,251 @@
-import { useEffect, useState } from "react";
-import { flagDataTypeMap } from "./AuthProvider.jsx";
-import { config } from "../config/index.js";
-import { routes } from "../config/index.js";
+import { useEffect, useState } from 'react';
+import { flagDataTypeMap } from './AuthProvider.jsx';
+import { config } from '../config/index.js';
+import { routes } from '../config/index.js';
 
 /**
  *
  * @returns {import('../../types.js').KindeState}
  */
 export const useKindeBrowserClient = (
-  apiPath = process.env.NEXT_PUBLIC_KINDE_AUTH_API_PATH ||
-    process.env.KINDE_AUTH_API_PATH ||
-    "/api/auth",
+	apiPath = process.env.NEXT_PUBLIC_KINDE_AUTH_API_PATH ||
+		process.env.KINDE_AUTH_API_PATH ||
+		'/api/auth'
 ) => {
-  const [state, setState] = useState({
-    accessToken: null,
-    accessTokenRaw: null,
-    error: null,
-    featureFlags: [],
-    idToken: null,
-    idTokenRaw: null,
-    isAuthenticated: false,
-    isLoading: true,
-    organization: null,
-    permissions: [],
-    user: null,
-    userOrganizations: null,
-  });
+	const [state, setState] = useState({
+		accessToken: null,
+		accessTokenRaw: null,
+		error: null,
+		featureFlags: [],
+		idToken: null,
+		idTokenRaw: null,
+		isAuthenticated: false,
+		isLoading: true,
+		organization: null,
+		permissions: [],
+		user: null,
+		userOrganizations: null,
+	});
 
-  useEffect(() => {
-    refreshData();
-  }, []);
+	useEffect(() => {
+		refreshData();
+	}, []);
 
-  const refreshData = async () => {
-    const setupUrl = `${apiPath}/${routes.setup}`;
-    const res = await fetch(setupUrl);
-    const kindeData = await res.json();
-    if (res.status == 200) {
-      setState({
-        ...kindeData,
-      });
-    }
-    if (res.ok) {
-      setState({ ...kindeData, isLoading: false });
-    } else {
-      setState((prev) => ({
-        ...prev,
-        isLoading: false,
-        error: res.statusText || "An error occurred",
-      }));
-    }
-  };
+	const refreshData = async () => {
+		const setupUrl = `${apiPath}/${routes.setup}`;
+		const res = await fetch(setupUrl);
+		const { message, error, ...kindeData } = await res.json();
+		if (!res.ok) {
+			setState((prev) => ({
+				...prev,
+				isLoading: false,
+				error: `${message}: ${error || 'An error occurred'}`,
+			}));
+			return;
+		}
 
-  /**
-   *
-   * @param {string} code
-   * @param {string | number | boolean} defaultValue
-   * @param {import('../../types.js').KindeFlagTypeCode} flagType
-   * @returns {import('../../types.js').KindeFlag}
-   */
-  const getFlag = (code, defaultValue, flagType) => {
-    const flags = state.featureFlags || [];
-    const flag = flags && flags[code] ? flags[code] : null;
+		switch (message) {
+			case 'OK':
+				setState({
+					...kindeData,
+					isLoading: false,
+				});
+				break;
+			case 'NOT_LOGGED_IN':
+				setState((prev) => ({
+					...prev,
+					isLoading: false,
+				}));
+				break;
+			default:
+				setState((prev) => ({
+					...prev,
+					isLoading: false,
+					error: `${message}: ${error || 'An error occurred'}`,
+				}));
+		}
+	};
 
-    if (!flag && defaultValue == undefined) {
-      throw Error(
-        `Flag ${code} was not found, and no default value has been provided`,
-      );
-    }
+	/**
+	 *
+	 * @param {string} code
+	 * @param {string | number | boolean} defaultValue
+	 * @param {import('../../types.js').KindeFlagTypeCode} flagType
+	 * @returns {import('../../types.js').KindeFlag}
+	 */
+	const getFlag = (code, defaultValue, flagType) => {
+		const flags = state.featureFlags || [];
+		const flag = flags && flags[code] ? flags[code] : null;
 
-    if (flagType && flag.t && flagType !== flag.t) {
-      throw Error(
-        `Flag ${code} is of type ${flagDataTypeMap[flag.t]} - requested type ${
-          flagDataTypeMap[flagType]
-        }`,
-      );
-    }
-    return {
-      code,
-      type: flagDataTypeMap[flag.t || flagType],
-      value: flag.v == null ? defaultValue : flag.v,
-      is_default: flag.v == null,
-      defaultValue: defaultValue,
-    };
-  };
+		if (!flag && defaultValue == undefined) {
+			throw Error(`Flag ${code} was not found, and no default value has been provided`);
+		}
 
-  /**
-   *
-   * @param {string} code
-   * @param {boolean} defaultValue
-   * @returns {boolean | undefined}
-   */
-  const getBooleanFlag = (
-    code: string,
-    defaultValue: boolean,
-  ): boolean | undefined => {
-    try {
-      const flag = getFlag(code, defaultValue, "b");
-      return flag.value;
-    } catch (err) {
-      if (config.isDebugMode) {
-        console.error(err);
-      }
-    }
-  };
+		if (flagType && flag.t && flagType !== flag.t) {
+			throw Error(
+				`Flag ${code} is of type ${flagDataTypeMap[flag.t]} - requested type ${
+					flagDataTypeMap[flagType]
+				}`
+			);
+		}
+		return {
+			code,
+			type: flagDataTypeMap[flag.t || flagType],
+			value: flag.v == null ? defaultValue : flag.v,
+			is_default: flag.v == null,
+			defaultValue: defaultValue,
+		};
+	};
 
-  /**
-   *
-   * @param {string} code
-   * @param {string} defaultValue
-   * @returns {string | undefined}
-   */
-  const getStringFlag = (
-    code: string,
-    defaultValue: string,
-  ): string | undefined => {
-    try {
-      const flag = getFlag(code, defaultValue, "s");
-      return flag.value;
-    } catch (err) {
-      if (config.isDebugMode) {
-        console.error(err);
-      }
-      err;
-    }
-  };
+	/**
+	 *
+	 * @param {string} code
+	 * @param {boolean} defaultValue
+	 * @returns {boolean | undefined}
+	 */
+	const getBooleanFlag = (code: string, defaultValue: boolean): boolean | undefined => {
+		try {
+			const flag = getFlag(code, defaultValue, 'b');
+			return flag.value;
+		} catch (err) {
+			if (config.isDebugMode) {
+				console.error(err);
+			}
+		}
+	};
 
-  /**
-   *
-   * @param {string} code
-   * @param {number} defaultValue
-   * @returns {number | undefined}
-   */
-  const getIntegerFlag = (
-    code: string,
-    defaultValue: number,
-  ): number | undefined => {
-    try {
-      const flag = getFlag(code, defaultValue, "i");
-      return flag.value;
-    } catch (err) {
-      if (config.isDebugMode) {
-        console.error(err);
-      }
-      err;
-    }
-  };
+	/**
+	 *
+	 * @param {string} code
+	 * @param {string} defaultValue
+	 * @returns {string | undefined}
+	 */
+	const getStringFlag = (code: string, defaultValue: string): string | undefined => {
+		try {
+			const flag = getFlag(code, defaultValue, 's');
+			return flag.value;
+		} catch (err) {
+			if (config.isDebugMode) {
+				console.error(err);
+			}
+			err;
+		}
+	};
 
-  /**
-   *
-   * @param {string} claim
-   * @param {"access_token" | "id_token"} tokenKey
-   * @returns
-   */
-  const getClaim = (claim, tokenKey = "access_token") => {
-    const token =
-      tokenKey === "access_token" ? state.accessToken : state.idToken;
-    return token ? { name: claim, value: token[claim] } : null;
-  };
+	/**
+	 *
+	 * @param {string} code
+	 * @param {number} defaultValue
+	 * @returns {number | undefined}
+	 */
+	const getIntegerFlag = (code: string, defaultValue: number): number | undefined => {
+		try {
+			const flag = getFlag(code, defaultValue, 'i');
+			return flag.value;
+		} catch (err) {
+			if (config.isDebugMode) {
+				console.error(err);
+			}
+			err;
+		}
+	};
 
-  /**
-   * @returns {import('../../types.js').KindeAccessToken | null}
-   */
-  const getAccessToken = () => {
-    return state.accessToken;
-  };
-  /**
-   * @returns {string | null}
-   */
-  const getToken = () => {
-    //@ts-ignore
-    return state.accessTokenEncoded;
-  };
+	/**
+	 *
+	 * @param {string} claim
+	 * @param {"access_token" | "id_token"} tokenKey
+	 * @returns
+	 */
+	const getClaim = (claim, tokenKey = 'access_token') => {
+		const token = tokenKey === 'access_token' ? state.accessToken : state.idToken;
+		return token ? { name: claim, value: token[claim] } : null;
+	};
 
-  /**
-   * @returns {string | null}
-   */
-  const getAccessTokenRaw = () => {
-    //@ts-ignore
-    return state.accessTokenEncoded;
-  };
+	/**
+	 * @returns {import('../../types.js').KindeAccessToken | null}
+	 */
+	const getAccessToken = () => {
+		return state.accessToken;
+	};
+	/**
+	 * @returns {string | null}
+	 */
+	const getToken = () => {
+		//@ts-ignore
+		return state.accessTokenEncoded;
+	};
 
-  /**
-   * @returns {string | null}
-   */
-  const getIdTokenRaw = () => {
-    return state.idTokenRaw;
-  };
-  /**
-   * @returns {import('../../types.js').KindeIdToken | null}
-   */
-  const getIdToken = () => {
-    return state.idToken;
-  };
-  /**
-   * @returns {import('../../types.js').KindeOrganization | null}
-   */
-  const getOrganization = () => {
-    return state.organization;
-  };
-  /**
-   * @returns {import('../../types.js').KindePermissions | never[]}
-   */
-  const getPermissions = () => {
-    return state.permissions;
-  };
-  /**
-   * @returns {import('../../types.js').KindeOrganizations | never[]}
-   */
-  const getUserOrganizations = () => {
-    return state.userOrganizations;
-  };
-  /**
-   *
-   * @param {string} key
-   * @returns {import('../../types.js').KindePermission}
-   */
-  const getPermission = (key) => {
-    if (!state.permissions) return { isGranted: false, orgCode: null };
+	/**
+	 * @returns {string | null}
+	 */
+	const getAccessTokenRaw = () => {
+		//@ts-ignore
+		return state.accessTokenEncoded;
+	};
 
-    return {
-      //@ts-ignore
-      isGranted: state.permissions.permissions?.some((p) => p === key),
-      orgCode: state.organization?.orgCode,
-    };
-  };
+	/**
+	 * @returns {string | null}
+	 */
+	const getIdTokenRaw = () => {
+		return state.idTokenRaw;
+	};
+	/**
+	 * @returns {import('../../types.js').KindeIdToken | null}
+	 */
+	const getIdToken = () => {
+		return state.idToken;
+	};
+	/**
+	 * @returns {import('../../types.js').KindeOrganization | null}
+	 */
+	const getOrganization = () => {
+		return state.organization;
+	};
+	/**
+	 * @returns {import('../../types.js').KindePermissions | never[]}
+	 */
+	const getPermissions = () => {
+		return state.permissions;
+	};
+	/**
+	 * @returns {import('../../types.js').KindeOrganizations | never[]}
+	 */
+	const getUserOrganizations = () => {
+		return state.userOrganizations;
+	};
+	/**
+	 *
+	 * @param {string} key
+	 * @returns {import('../../types.js').KindePermission}
+	 */
+	const getPermission = (key) => {
+		if (!state.permissions) return { isGranted: false, orgCode: null };
 
-  return {
-    ...state,
-    isAuthenticated: !!state.user,
-    getUser: () => state.user,
-    getIdTokenRaw,
-    getPermission,
-    getBooleanFlag,
-    getIntegerFlag,
-    getFlag,
-    getStringFlag,
-    getClaim,
-    getAccessToken,
-    getToken,
-    getAccessTokenRaw,
-    getIdToken,
-    getOrganization,
-    getPermissions,
-    getUserOrganizations,
-    refreshData,
-  };
+		return {
+			//@ts-ignore
+			isGranted: state.permissions.permissions?.some((p) => p === key),
+			orgCode: state.organization?.orgCode,
+		};
+	};
+
+	return {
+		...state,
+		isAuthenticated: !!state.user,
+		getUser: () => state.user,
+		getIdTokenRaw,
+		getPermission,
+		getBooleanFlag,
+		getIntegerFlag,
+		getFlag,
+		getStringFlag,
+		getClaim,
+		getAccessToken,
+		getToken,
+		getAccessTokenRaw,
+		getIdToken,
+		getOrganization,
+		getPermissions,
+		getUserOrganizations,
+		refreshData,
+	};
 };

--- a/src/handlers/setup.ts
+++ b/src/handlers/setup.ts
@@ -1,118 +1,140 @@
-import { jwtDecoder } from "@kinde/jwt-decoder";
-import { KindeAccessToken, KindeIdToken } from "../../types";
-import { config } from "../config/index";
-import { generateUserObject } from "../utils/generateUserObject";
-import { validateToken } from "@kinde/jwt-validator";
-import { refreshTokens } from "../utils/refreshTokens";
+import { jwtDecoder } from '@kinde/jwt-decoder';
+import { KindeAccessToken, KindeIdToken } from '../../types';
+import { config } from '../config/index';
+import { generateUserObject } from '../utils/generateUserObject';
+import { validateToken } from '@kinde/jwt-validator';
+import { refreshTokens } from '../utils/refreshTokens';
+import { getAccessToken } from '../utils/getAccessToken';
+import RouterClient from '../routerClients/RouterClient';
+import { getIdToken } from '../utils/getIdToken';
+import { isTokenExpired } from '../utils/jwt/validation';
+import { sessionManager } from '../session/sessionManager';
+import { kindeClient } from '../session/kindeServerClient';
 
 /**
  *
  * @param {RouterClient} routerClient
  * @returns
  */
-export const setup = async (routerClient) => {
-  try {
-    let accessTokenEncoded =
-      await routerClient.sessionManager.getSessionItem("access_token");
+export const setup = async (routerClient: RouterClient) => {
+	try {
+		let accessTokenEncoded = await getAccessToken(routerClient.req);
+		let idTokenEncoded = await getIdToken(routerClient.req);
 
-    const isAccessTokenValid = await validateToken({
-      token: accessTokenEncoded,
-    });
+		if (!accessTokenEncoded || !idTokenEncoded) {
+			if (config.isDebugMode) {
+				console.log('setup: no access or id token - returning NOT_LOGGED_IN');
+			}
+			return routerClient.json(
+				{
+					message: 'NOT_LOGGED_IN',
+				},
+				{ status: 200 }
+			);
+		}
 
-    if (!isAccessTokenValid) {
-      if (!(await refreshTokens(routerClient.sessionManager))) {
-        throw new Error("Invalid access token and refresh");
-      }
-      accessTokenEncoded =
-        await routerClient.sessionManager.getSessionItem("access_token");
-    }
+		const session = await sessionManager(routerClient.req);
 
-    let idTokenEncoded =
-      await routerClient.sessionManager.getSessionItem("id_token");
+		if (isTokenExpired(accessTokenEncoded) || isTokenExpired(idTokenEncoded)) {
+			if (config.isDebugMode) {
+				console.log('setup: access or id token expired - attempting refresh');
+			}
+			try {
+				const refreshResponse = await kindeClient.refreshTokens(session);
+				accessTokenEncoded = refreshResponse.access_token;
+				idTokenEncoded = refreshResponse.id_token;
+			} catch (error) {
+				if (config.isDebugMode) {
+					console.error('setup: refresh tokens failed - returning error');
+				}
+				return routerClient.json({ message: 'REFRESH_FAILED', error }, { status: 500 });
+			}
+		}
 
-    const isIdTokenValid = await validateToken({
-      token: idTokenEncoded,
-    });
+		let accessToken: KindeAccessToken | null = null;
+		let idToken: KindeIdToken | null = null;
 
-    if (!isIdTokenValid) {
-      if (!(await refreshTokens(routerClient.sessionManager))) {
-        throw new Error("Invalid access token and refresh");
-      }
-      idTokenEncoded =
-        await routerClient.sessionManager.getSessionItem("id_token");
-    }
+		try {
+			accessToken = jwtDecoder<KindeAccessToken>(accessTokenEncoded);
+		} catch (error) {
+			if (config.isDebugMode) {
+				console.error('setup: access token decode failed, redirecting to login');
+			}
+			return routerClient.json({ message: 'ACCESS_TOKEN_DECODE_FAILED', error }, { status: 500 });
+		}
 
-    const accessToken = jwtDecoder<KindeAccessToken>(accessTokenEncoded);
-    const idToken = jwtDecoder<KindeIdToken>(idTokenEncoded);
+		try {
+			idToken = jwtDecoder<KindeIdToken>(idTokenEncoded);
+		} catch (error) {
+			if (config.isDebugMode) {
+				console.error('setup: id token decode failed, redirecting to login');
+			}
+			return routerClient.json({ message: 'ID_TOKEN_DECODE_FAILED', error }, { status: 500 });
+		}
 
-    const permissions = accessToken.permissions;
+		if (!accessToken || !idToken) {
+			return routerClient.json({ message: 'TOKENS_MISSING', error: 'No access or id token' }, { status: 500 });
+		}
 
-    const organization = accessToken.org_code;
-    const featureFlags = accessToken.feature_flags;
-    const userOrganizations = idToken.org_codes;
-    const orgName = accessToken.org_name;
-    const orgProperties = accessToken.organization_properties;
-    const orgNames = idToken.organizations;
+		const permissions = accessToken.permissions;
 
-    if (!accessToken.permissions || !idToken.org_codes) {
-      throw new Error("Missing required claims in tokens");
-    }
+		const organization = accessToken.org_code;
+		const featureFlags = accessToken.feature_flags;
+		const userOrganizations = idToken.org_codes;
+		const orgName = accessToken.org_name;
+		const orgProperties = accessToken.organization_properties;
+		const orgNames = idToken.organizations;
 
-    return routerClient.json({
-      accessToken,
-      accessTokenEncoded,
-      accessTokenRaw: accessTokenEncoded,
-      idToken,
-      idTokenRaw: idTokenEncoded,
-      idTokenEncoded,
-      user: generateUserObject(
-        idToken as KindeIdToken,
-        accessToken as KindeAccessToken,
-      ),
-      permissions: {
-        permissions,
-        orgCode: organization,
-      },
-      needsRefresh: false,
-      organization: {
-        orgCode: organization,
-        orgName,
-        properties: {
-          city: orgProperties?.kp_org_city?.v,
-          industry: orgProperties?.kp_org_industry?.v,
-          postcode: orgProperties?.kp_org_postcode?.v,
-          state_region: orgProperties?.kp_org_state_region?.v,
-          street_address: orgProperties?.kp_org_street_address?.v,
-          street_address_2: orgProperties?.kp_org_street_address_2?.v,
-        },
-      },
-      featureFlags,
-      userOrganizations: {
-        orgCodes: userOrganizations,
-        orgs: orgNames?.map((org) => ({
-          code: org?.id,
-          name: org?.name,
-        })),
-      },
-    });
-  } catch (error) {
-    if (config.isDebugMode) {
-      console.debug(error);
-    }
+		if (!accessToken.permissions || !idToken.org_codes) {
+			return routerClient.json({ message: 'MISSING_REQUIRED_CLAIMS' }, { status: 500 });
+		}
 
-    if (error.code == "ERR_JWT_EXPIRED") {
-      return routerClient.json(
-        {
-          needsRefresh: true,
-        },
-        { status: 200 },
-      );
-    }
-    return routerClient.json(
-      {
-        error,
-      },
-      { status: 500 },
-    );
-  }
+		return routerClient.json({
+			accessToken,
+			accessTokenEncoded,
+			accessTokenRaw: accessTokenEncoded,
+			idToken,
+			idTokenRaw: idTokenEncoded,
+			idTokenEncoded,
+			user: generateUserObject(idToken, accessToken),
+			permissions: {
+				permissions,
+				orgCode: organization,
+			},
+			needsRefresh: false,
+			message: 'OK',
+			organization: {
+				orgCode: organization,
+				orgName,
+				properties: {
+					city: orgProperties?.kp_org_city?.v,
+					industry: orgProperties?.kp_org_industry?.v,
+					postcode: orgProperties?.kp_org_postcode?.v,
+					state_region: orgProperties?.kp_org_state_region?.v,
+					street_address: orgProperties?.kp_org_street_address?.v,
+					street_address_2: orgProperties?.kp_org_street_address_2?.v,
+				},
+			},
+			featureFlags,
+			userOrganizations: {
+				orgCodes: userOrganizations,
+				orgs: orgNames?.map((org) => ({
+					code: org?.id,
+					name: org?.name,
+				})),
+			},
+		});
+	} catch (error) {
+		if (config.isDebugMode) {
+			console.error('setup: failed, error: ', error);
+		}
+
+		return routerClient.json(
+			{
+				message: 'SETUP_FAILED',
+				error,
+			},
+			{ status: 500 }
+		);
+	}
 };


### PR DESCRIPTION
# Explain your changes

The `setup` route handler was validating incorrectly and threw raw errors (which Next converts into 500's), even if a user wasn't logged in, which was the source of a constant stream of 500 errors if a user was using the browser client hook.

The `setup` route handler has been reworked to do the following:
- If a user is not logged in (access token or id token does not exist in a session), return a status message but with a 200.
  - A user not being logged in is not exactly an error, so a 500 status wouldn't fit here.
- When actual errors occur, return a descriptive status message and error with a 500 status.
- Correctly validate and return refreshed tokens.

### Note: refreshing and revalidating is largely redundant in the Setup handler as it's now handled by middleware. I'm leaving it here for the sake of preserving functionality, but we should considering revisiting and removing this in v3.

`useKindeBrowserClient` has been updated to respect the new messaging and status scheme.

The end result is users will now see 200 status fetches to their setup route even if a user isn't logged in.

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
