### PR TITLE
fix missed rollup errors

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,7 +1,7 @@
 import clientConfig from "./rollupConfig/clientConfig.config.js";
 import serverConfig from "./rollupConfig/serverConfig.config.js";
 import componentConfig from "./rollupConfig/componentConfig.config.js";
-import middlewareConfig from "./rollupConfig/middlewearConfig.config.js";
+import middlewareConfig from "./rollupConfig/middlewareConfig.config.js";
 
 export default [
     clientConfig,

--- a/rollupConfig/clientConfig.config.js
+++ b/rollupConfig/clientConfig.config.js
@@ -1,4 +1,3 @@
-import packageJson from "../package.json" with { type: "json" };
 import babel from "@rollup/plugin-babel";
 import { terser } from "rollup-plugin-terser";
 import tsPlugin from "@rollup/plugin-typescript";


### PR DESCRIPTION
# Explain your changes

I didn't clean my working directory before reviewing #276, so I was inadvertently reviewing the existing and working config - big oops on my behalf.

This pushes typo fixes upstream.

Build log:
<img width="1158" alt="image" src="https://github.com/user-attachments/assets/2a696909-00bd-4c01-a1dd-ec9c0353f868" />


# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
