### PR TITLE
fix: export the correct type declaration

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,8 +49,8 @@
     },
     "./types": {
       "import": {
-        "types": "./dist/index.d.ts",
-        "default": "./dist/types.js"
+        "types": "./dist/types.d.ts",
+        "default": "./dist/index.js"
       }
     }
   },


### PR DESCRIPTION
# Explain your changes

`package.json` was no longer pointing to the correct type declaration file, meaning attempting to import types from `@kinde-oss/kinde-auth-nextjs/types` resulted in errors. This corrects that.

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
