### PR TITLE
fix: postLoginRedirectURL within callback

### DIFF
--- a/src/handlers/callback.ts
+++ b/src/handlers/callback.ts
@@ -68,10 +68,9 @@ export const callback = async (routerClient: RouterClient) => {
   await routerClient.sessionManager.removeSessionItem("state");
 
   if (postLoginRedirectURL && isRedirectAllowed(postLoginRedirectURL)) {
-    const url = new URL(
-      `${postLoginRedirectURL.startsWith("http") ? "" : routerClient.clientConfig.siteUrl}`,
-      postLoginRedirectURL,
-    );
+    const url = postLoginRedirectURL.startsWith('http')
+			? new URL(postLoginRedirectURL)
+			: new URL(postLoginRedirectURL, routerClient.clientConfig.siteUrl);
     state && url.searchParams.set("state", state);
     return routerClient.redirect(url.toString());
   }


### PR DESCRIPTION
`postLoginRedirectURL` was passing parameters to `URL` in the incorrect order - the correct parameter order is `input` (the relative path), then `base`. This was happening in reverse order (we were passing `base` then `relative`). This PR resolves this.

Tested on `next@14.2.24`, `next@15.2.2`