### PR TITLE
fix: change tsconfig for consistency 

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,8 +7,8 @@
     "allowJs": true,
     "baseUrl": ".",
     "jsx": "react",
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
     "lib": [
       "es6",
       "dom"


### PR DESCRIPTION
`"module": "NodeNext"` and `"moduleResolution": "NodeNext"` resulted in strange inconsistencies between different machines (and CI actions)

tsconfig has been updated to `ES2022` and `bundler` for maintaining consistency