### PR TITLE
feat: queue setup requests to prevent double refresh

### DIFF
--- a/src/authMiddleware/authMiddleware.ts
+++ b/src/authMiddleware/authMiddleware.ts
@@ -10,7 +10,7 @@ import { getSplitCookies } from "../utils/cookies/getSplitSerializedCookies";
 import { getIdToken } from "../utils/getIdToken";
 import { OAuth2CodeExchangeResponse } from "@kinde-oss/kinde-typescript-sdk";
 import { copyCookiesToRequest } from "../utils/copyCookiesToRequest";
-import { getStandardCookieOptions } from "src/utils/cookies/getStandardCookieOptions";
+import { getStandardCookieOptions } from "../utils/cookies/getStandardCookieOptions";
 
 const handleMiddleware = async (req, options, onSuccess) => {
   const { pathname } = req.nextUrl;
@@ -136,7 +136,11 @@ const handleMiddleware = async (req, options, onSuccess) => {
         resp.cookies.set(cookie.name, cookie.value, cookie.options);
       });
 
-      resp.cookies.set("refresh_token", refreshResponse.refresh_token, getStandardCookieOptions());
+      resp.cookies.set(
+        "refresh_token",
+        refreshResponse.refresh_token,
+        getStandardCookieOptions(),
+      );
 
       // copy the cookies from the response to the request
       // in Next versions prior to 14.2.8, the cookies function

--- a/src/handlers/setup.ts
+++ b/src/handlers/setup.ts
@@ -2,14 +2,13 @@ import { jwtDecoder } from "@kinde/jwt-decoder";
 import { KindeAccessToken, KindeIdToken } from "../types";
 import { config } from "../config/index";
 import { generateUserObject } from "../utils/generateUserObject";
-import { validateToken } from "@kinde/jwt-validator";
-import { refreshTokens } from "../utils/refreshTokens";
 import { getAccessToken } from "../utils/getAccessToken";
 import RouterClient from "../routerClients/RouterClient";
 import { getIdToken } from "../utils/getIdToken";
 import { isTokenExpired } from "../utils/jwt/validation";
 import { sessionManager } from "../session/sessionManager";
 import { kindeClient } from "../session/kindeServerClient";
+import { RequestQueueManager } from "../utils/workQueue";
 
 /**
  *
@@ -17,134 +16,141 @@ import { kindeClient } from "../session/kindeServerClient";
  * @returns
  */
 export const setup = async (routerClient: RouterClient) => {
-  try {
-    let accessTokenEncoded = await getAccessToken(routerClient.req);
-    let idTokenEncoded = await getIdToken(routerClient.req);
+  const queueManager = RequestQueueManager.getInstance();
 
-    if (!accessTokenEncoded || !idTokenEncoded) {
-      if (config.isDebugMode) {
-        console.log("setup: no access or id token - returning NOT_LOGGED_IN");
-      }
-      return routerClient.json(
-        {
-          message: "NOT_LOGGED_IN",
-        },
-        { status: 200 },
-      );
-    }
+  return queueManager.enqueue(async () => {
+    try {
+      let accessTokenEncoded = await getAccessToken(routerClient.req);
+      let idTokenEncoded = await getIdToken(routerClient.req);
 
-    const session = await sessionManager(routerClient.req);
-
-    if (isTokenExpired(accessTokenEncoded) || isTokenExpired(idTokenEncoded)) {
-      if (config.isDebugMode) {
-        console.log("setup: access or id token expired - attempting refresh");
-      }
-      try {
-        const refreshResponse = await kindeClient.refreshTokens(session);
-        accessTokenEncoded = refreshResponse.access_token;
-        idTokenEncoded = refreshResponse.id_token;
-      } catch (error) {
+      if (!accessTokenEncoded || !idTokenEncoded) {
         if (config.isDebugMode) {
-          console.error("setup: refresh tokens failed - returning error");
+          console.log("setup: no access or id token - returning NOT_LOGGED_IN");
         }
         return routerClient.json(
-          { message: "REFRESH_FAILED", error },
+          {
+            message: "NOT_LOGGED_IN",
+          },
+          { status: 200 },
+        );
+      }
+
+      const session = await sessionManager(routerClient.req);
+
+      if (
+        isTokenExpired(accessTokenEncoded) ||
+        isTokenExpired(idTokenEncoded)
+      ) {
+        if (config.isDebugMode) {
+          console.log("setup: access or id token expired - attempting refresh");
+        }
+        try {
+          const refreshResponse = await kindeClient.refreshTokens(session);
+          accessTokenEncoded = refreshResponse.access_token;
+          idTokenEncoded = refreshResponse.id_token;
+        } catch (error) {
+          if (config.isDebugMode) {
+            console.error("setup: refresh tokens failed - returning error");
+          }
+          return routerClient.json(
+            { message: "REFRESH_FAILED", error },
+            { status: 500 },
+          );
+        }
+      }
+
+      let accessToken: KindeAccessToken | null = null;
+      let idToken: KindeIdToken | null = null;
+
+      try {
+        accessToken = jwtDecoder<KindeAccessToken>(accessTokenEncoded);
+      } catch (error) {
+        if (config.isDebugMode) {
+          console.error(
+            "setup: access token decode failed, redirecting to login",
+          );
+        }
+        return routerClient.json(
+          { message: "ACCESS_TOKEN_DECODE_FAILED", error },
           { status: 500 },
         );
       }
-    }
 
-    let accessToken: KindeAccessToken | null = null;
-    let idToken: KindeIdToken | null = null;
-
-    try {
-      accessToken = jwtDecoder<KindeAccessToken>(accessTokenEncoded);
-    } catch (error) {
-      if (config.isDebugMode) {
-        console.error(
-          "setup: access token decode failed, redirecting to login",
+      try {
+        idToken = jwtDecoder<KindeIdToken>(idTokenEncoded);
+      } catch (error) {
+        if (config.isDebugMode) {
+          console.error("setup: id token decode failed, redirecting to login");
+        }
+        return routerClient.json(
+          { message: "ID_TOKEN_DECODE_FAILED", error },
+          { status: 500 },
         );
       }
-      return routerClient.json(
-        { message: "ACCESS_TOKEN_DECODE_FAILED", error },
-        { status: 500 },
-      );
-    }
 
-    try {
-      idToken = jwtDecoder<KindeIdToken>(idTokenEncoded);
+      if (!accessToken || !idToken) {
+        return routerClient.json(
+          { message: "TOKENS_MISSING", error: "No access or id token" },
+          { status: 500 },
+        );
+      }
+
+      const permissions = accessToken.permissions;
+
+      const organization = accessToken.org_code;
+      const featureFlags = accessToken.feature_flags;
+      const userOrganizations = idToken.org_codes;
+      const orgName = accessToken.org_name;
+      const orgProperties = accessToken.organization_properties;
+      const orgNames = idToken.organizations;
+
+      return routerClient.json({
+        accessToken,
+        accessTokenEncoded,
+        accessTokenRaw: accessTokenEncoded,
+        idToken,
+        idTokenRaw: idTokenEncoded,
+        idTokenEncoded,
+        user: generateUserObject(idToken, accessToken),
+        permissions: {
+          permissions,
+          orgCode: organization,
+        },
+        needsRefresh: false,
+        message: "OK",
+        organization: {
+          orgCode: organization,
+          orgName,
+          properties: {
+            city: orgProperties?.kp_org_city?.v,
+            industry: orgProperties?.kp_org_industry?.v,
+            postcode: orgProperties?.kp_org_postcode?.v,
+            state_region: orgProperties?.kp_org_state_region?.v,
+            street_address: orgProperties?.kp_org_street_address?.v,
+            street_address_2: orgProperties?.kp_org_street_address_2?.v,
+          },
+        },
+        featureFlags,
+        userOrganizations: {
+          orgCodes: userOrganizations,
+          orgs: orgNames?.map((org) => ({
+            code: org?.id,
+            name: org?.name,
+          })),
+        },
+      });
     } catch (error) {
       if (config.isDebugMode) {
-        console.error("setup: id token decode failed, redirecting to login");
+        console.error("setup: failed, error: ", error);
       }
+
       return routerClient.json(
-        { message: "ID_TOKEN_DECODE_FAILED", error },
-        { status: 500 },
-      );
-    }
-
-    if (!accessToken || !idToken) {
-      return routerClient.json(
-        { message: "TOKENS_MISSING", error: "No access or id token" },
-        { status: 500 },
-      );
-    }
-
-    const permissions = accessToken.permissions;
-
-    const organization = accessToken.org_code;
-    const featureFlags = accessToken.feature_flags;
-    const userOrganizations = idToken.org_codes;
-    const orgName = accessToken.org_name;
-    const orgProperties = accessToken.organization_properties;
-    const orgNames = idToken.organizations;
-
-    return routerClient.json({
-      accessToken,
-      accessTokenEncoded,
-      accessTokenRaw: accessTokenEncoded,
-      idToken,
-      idTokenRaw: idTokenEncoded,
-      idTokenEncoded,
-      user: generateUserObject(idToken, accessToken),
-      permissions: {
-        permissions,
-        orgCode: organization,
-      },
-      needsRefresh: false,
-      message: "OK",
-      organization: {
-        orgCode: organization,
-        orgName,
-        properties: {
-          city: orgProperties?.kp_org_city?.v,
-          industry: orgProperties?.kp_org_industry?.v,
-          postcode: orgProperties?.kp_org_postcode?.v,
-          state_region: orgProperties?.kp_org_state_region?.v,
-          street_address: orgProperties?.kp_org_street_address?.v,
-          street_address_2: orgProperties?.kp_org_street_address_2?.v,
+        {
+          message: "SETUP_FAILED",
+          error,
         },
-      },
-      featureFlags,
-      userOrganizations: {
-        orgCodes: userOrganizations,
-        orgs: orgNames?.map((org) => ({
-          code: org?.id,
-          name: org?.name,
-        })),
-      },
-    });
-  } catch (error) {
-    if (config.isDebugMode) {
-      console.error("setup: failed, error: ", error);
+        { status: 500 },
+      );
     }
-
-    return routerClient.json(
-      {
-        message: "SETUP_FAILED",
-        error,
-      },
-      { status: 500 },
-    );
-  }
+  });
 };

--- a/src/utils/cookies/getSplitSerializedCookies.ts
+++ b/src/utils/cookies/getSplitSerializedCookies.ts
@@ -1,13 +1,13 @@
-import { MAX_COOKIE_LENGTH } from '../constants';
-import { splitString } from '../splitString';
-import { getStandardCookieOptions } from 'src/utils/cookies/getStandardCookieOptions';
+import { MAX_COOKIE_LENGTH } from "../constants";
+import { splitString } from "../splitString";
+import { getStandardCookieOptions } from "../../utils/cookies/getStandardCookieOptions";
 
 export const getSplitCookies = (cookieName: string, cookieValue: string) => {
   return splitString(cookieValue, MAX_COOKIE_LENGTH).map((value, index) => {
     return {
-      name: cookieName + (index === 0 ? '' : index),
+      name: cookieName + (index === 0 ? "" : index),
       value: value,
-      options: getStandardCookieOptions()
+      options: getStandardCookieOptions(),
     };
   });
 };

--- a/src/utils/cookies/getStandardCookieOptions.ts
+++ b/src/utils/cookies/getStandardCookieOptions.ts
@@ -1,8 +1,11 @@
-import { ResponseCookie } from 'next/dist/compiled/@edge-runtime/cookies';
-import { config } from 'src/config';
-import { GLOBAL_COOKIE_OPTIONS, TWENTY_NINE_DAYS } from 'src/utils/constants';
+import { ResponseCookie } from "next/dist/compiled/@edge-runtime/cookies";
+import { config } from "../../config";
+import { GLOBAL_COOKIE_OPTIONS, TWENTY_NINE_DAYS } from "../../utils/constants";
 
-export const getStandardCookieOptions = (): Omit<ResponseCookie, 'name' | 'value'> => {
+export const getStandardCookieOptions = (): Omit<
+  ResponseCookie,
+  "name" | "value"
+> => {
   return {
     maxAge: TWENTY_NINE_DAYS,
     domain: config.cookieDomain ? config.cookieDomain : undefined,

--- a/src/utils/workQueue.ts
+++ b/src/utils/workQueue.ts
@@ -1,0 +1,51 @@
+type QueueItem = {
+  execute: () => Promise<any>;
+  resolve: (value: any) => void;
+  reject: (error: any) => void;
+};
+
+export class RequestQueueManager {
+  private static instance: RequestQueueManager;
+  private isProcessing: boolean = false;
+  private queue: QueueItem[] = [];
+
+  private constructor() {}
+
+  static getInstance(): RequestQueueManager {
+    if (!RequestQueueManager.instance) {
+      RequestQueueManager.instance = new RequestQueueManager();
+    }
+    return RequestQueueManager.instance;
+  }
+
+  async enqueue<T>(task: () => Promise<T>): Promise<T> {
+    return new Promise((resolve, reject) => {
+        console.debug("enqueue: task added to queue");
+      this.queue.push({
+        execute: task,
+        resolve,
+        reject,
+      });
+      this.processQueue();
+    });
+  }
+
+  private async processQueue() {
+    if (this.isProcessing || this.queue.length === 0) return;
+
+    this.isProcessing = true;
+    const item = this.queue.shift()!;
+
+    try {
+      const result = await item.execute();
+      console.debug("processQueue: task executed successfully");
+      item.resolve(result);
+    } catch (error) {
+        console.debug("processQueue: task execution failed", error);
+      item.reject(error);
+    } finally {
+      this.isProcessing = false;
+      this.processQueue();
+    }
+  }
+}


### PR DESCRIPTION
# Explain your changes

When there are multiple client components using the browser client, this can cause multiple calls to `/setup` endpoint.

While middleware and provider could help and solve here, there are cases where setups are not configured like this.  To help these configurations calls to `setup` are now queued and executed one at a time.  This will be prevent double token refresh which can result in unwanted application logouts. 

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
