### PR TITLE
fix: set refresh token opts in middleware

### DIFF
--- a/src/authMiddleware/authMiddleware.ts
+++ b/src/authMiddleware/authMiddleware.ts
@@ -10,6 +10,7 @@ import { getSplitCookies } from "../utils/cookies/getSplitSerializedCookies";
 import { getIdToken } from "../utils/getIdToken";
 import { OAuth2CodeExchangeResponse } from "@kinde-oss/kinde-typescript-sdk";
 import { copyCookiesToRequest } from "../utils/copyCookiesToRequest";
+import { getStandardCookieOptions } from "src/utils/cookies/getStandardCookieOptions";
 
 const handleMiddleware = async (req, options, onSuccess) => {
   const { pathname } = req.nextUrl;
@@ -135,7 +136,7 @@ const handleMiddleware = async (req, options, onSuccess) => {
         resp.cookies.set(cookie.name, cookie.value, cookie.options);
       });
 
-      resp.cookies.set("refresh_token", refreshResponse.refresh_token);
+      resp.cookies.set("refresh_token", refreshResponse.refresh_token, getStandardCookieOptions());
 
       // copy the cookies from the response to the request
       // in Next versions prior to 14.2.8, the cookies function

--- a/src/utils/cookies/getSplitSerializedCookies.ts
+++ b/src/utils/cookies/getSplitSerializedCookies.ts
@@ -1,22 +1,13 @@
-import {
-  GLOBAL_COOKIE_OPTIONS,
-  MAX_COOKIE_LENGTH,
-  TWENTY_NINE_DAYS,
-} from "../constants";
-import { splitString } from "../splitString";
-import { config } from "../../config";
-import { RequestCookie } from "next/dist/compiled/@edge-runtime/cookies";
+import { MAX_COOKIE_LENGTH } from '../constants';
+import { splitString } from '../splitString';
+import { getStandardCookieOptions } from 'src/utils/cookies/getStandardCookieOptions';
 
 export const getSplitCookies = (cookieName: string, cookieValue: string) => {
   return splitString(cookieValue, MAX_COOKIE_LENGTH).map((value, index) => {
     return {
-      name: cookieName + (index === 0 ? "" : index),
+      name: cookieName + (index === 0 ? '' : index),
       value: value,
-      options: {
-        maxAge: TWENTY_NINE_DAYS,
-        domain: config.cookieDomain ? config.cookieDomain : undefined,
-        ...GLOBAL_COOKIE_OPTIONS,
-      } as Partial<RequestCookie>,
+      options: getStandardCookieOptions()
     };
   });
 };

--- a/src/utils/cookies/getStandardCookieOptions.ts
+++ b/src/utils/cookies/getStandardCookieOptions.ts
@@ -2,7 +2,7 @@ import { ResponseCookie } from 'next/dist/compiled/@edge-runtime/cookies';
 import { config } from 'src/config';
 import { GLOBAL_COOKIE_OPTIONS, TWENTY_NINE_DAYS } from 'src/utils/constants';
 
-export const getStandardCookieOptions = (): Partial<ResponseCookie> => {
+export const getStandardCookieOptions = (): Omit<ResponseCookie, 'name' | 'value'> => {
   return {
     maxAge: TWENTY_NINE_DAYS,
     domain: config.cookieDomain ? config.cookieDomain : undefined,

--- a/src/utils/cookies/getStandardCookieOptions.ts
+++ b/src/utils/cookies/getStandardCookieOptions.ts
@@ -1,0 +1,11 @@
+import { ResponseCookie } from 'next/dist/compiled/@edge-runtime/cookies';
+import { config } from 'src/config';
+import { GLOBAL_COOKIE_OPTIONS, TWENTY_NINE_DAYS } from 'src/utils/constants';
+
+export const getStandardCookieOptions = (): Partial<ResponseCookie> => {
+  return {
+    maxAge: TWENTY_NINE_DAYS,
+    domain: config.cookieDomain ? config.cookieDomain : undefined,
+    ...GLOBAL_COOKIE_OPTIONS,
+  };
+};


### PR DESCRIPTION
Creates a new function called `getStandardCookieOptions` for retrieving our standard cookies options for requests and responses.

`getSplitCookies` has been changed to also use this new function.

The refresh token passed down in middleware was optionless (as it had no need to be split, thus `getSplitCookies` was never called, thus options were never provided for the `refresh_token`), this change now appropriately sets our standard cookies options.

