### PR TITLE
deps: update kinde TS SDK

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "react-dom": "^18 || ^19"
   },
   "dependencies": {
-    "@kinde-oss/kinde-typescript-sdk": "2.11.0",
+    "@kinde-oss/kinde-typescript-sdk": "2.11.1",
     "@kinde/js-utils": "^0.18.1",
     "@kinde/jwt-decoder": "^0.2.0",
     "@kinde/jwt-validator": "^0.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@kinde-oss/kinde-typescript-sdk':
-        specifier: 2.11.0
-        version: 2.11.0(eslint@9.24.0)(typescript@5.7.3)
+        specifier: 2.11.1
+        version: 2.11.1(eslint@9.24.0)(typescript@5.7.3)
       '@kinde/js-utils':
         specifier: ^0.18.1
         version: 0.18.1
@@ -86,7 +86,7 @@ importers:
         version: 3.5.2
       release-it:
         specifier: ^18.1.2
-        version: 18.1.2(@types/node@22.15.29)(typescript@5.7.3)
+        version: 18.1.2(@types/node@24.0.3)(typescript@5.7.3)
       rollup-plugin-preserve-directives:
         specifier: ^0.4.0
         version: 0.4.0(rollup@4.34.8)
@@ -95,13 +95,13 @@ importers:
         version: 5.7.3
       vite:
         specifier: ^6.2.5
-        version: 6.2.5(@types/node@22.15.29)
+        version: 6.2.5(@types/node@24.0.3)
       vite-plugin-dts:
         specifier: ^4.5.3
-        version: 4.5.3(@types/node@22.15.29)(rollup@4.34.8)(typescript@5.7.3)(vite@6.2.5)
+        version: 4.5.3(@types/node@24.0.3)(rollup@4.34.8)(typescript@5.7.3)(vite@6.2.5)
       vitest:
         specifier: ^3.0.5
-        version: 3.0.7(@types/node@22.15.29)(happy-dom@17.1.1)
+        version: 3.0.7(@types/node@24.0.3)(happy-dom@17.1.1)
 
   playground:
     dependencies:
@@ -822,7 +822,7 @@ packages:
     dev: false
     optional: true
 
-  /@inquirer/checkbox@4.1.2(@types/node@22.15.29):
+  /@inquirer/checkbox@4.1.2(@types/node@24.0.3):
     resolution: {integrity: sha512-PL9ixC5YsPXzXhAZFUPmkXGxfgjkdfZdPEPPmt4kFwQ4LBMDG9n/nHXYRGGZSKZJs+d1sGKWgS2GiPzVRKUdtQ==}
     engines: {node: '>=18'}
     peerDependencies:
@@ -831,15 +831,15 @@ packages:
       '@types/node':
         optional: true
     dependencies:
-      '@inquirer/core': 10.1.7(@types/node@22.15.29)
+      '@inquirer/core': 10.1.7(@types/node@24.0.3)
       '@inquirer/figures': 1.0.10
-      '@inquirer/type': 3.0.4(@types/node@22.15.29)
-      '@types/node': 22.15.29
+      '@inquirer/type': 3.0.4(@types/node@24.0.3)
+      '@types/node': 24.0.3
       ansi-escapes: 4.3.2
       yoctocolors-cjs: 2.1.2
     dev: true
 
-  /@inquirer/confirm@5.1.6(@types/node@22.15.29):
+  /@inquirer/confirm@5.1.6(@types/node@24.0.3):
     resolution: {integrity: sha512-6ZXYK3M1XmaVBZX6FCfChgtponnL0R6I7k8Nu+kaoNkT828FVZTcca1MqmWQipaW2oNREQl5AaPCUOOCVNdRMw==}
     engines: {node: '>=18'}
     peerDependencies:
@@ -848,12 +848,12 @@ packages:
       '@types/node':
         optional: true
     dependencies:
-      '@inquirer/core': 10.1.7(@types/node@22.15.29)
-      '@inquirer/type': 3.0.4(@types/node@22.15.29)
-      '@types/node': 22.15.29
+      '@inquirer/core': 10.1.7(@types/node@24.0.3)
+      '@inquirer/type': 3.0.4(@types/node@24.0.3)
+      '@types/node': 24.0.3
     dev: true
 
-  /@inquirer/core@10.1.7(@types/node@22.15.29):
+  /@inquirer/core@10.1.7(@types/node@24.0.3):
     resolution: {integrity: sha512-AA9CQhlrt6ZgiSy6qoAigiA1izOa751ugX6ioSjqgJ+/Gd+tEN/TORk5sUYNjXuHWfW0r1n/a6ak4u/NqHHrtA==}
     engines: {node: '>=18'}
     peerDependencies:
@@ -863,8 +863,8 @@ packages:
         optional: true
     dependencies:
       '@inquirer/figures': 1.0.10
-      '@inquirer/type': 3.0.4(@types/node@22.15.29)
-      '@types/node': 22.15.29
+      '@inquirer/type': 3.0.4(@types/node@24.0.3)
+      '@types/node': 24.0.3
       ansi-escapes: 4.3.2
       cli-width: 4.1.0
       mute-stream: 2.0.0
@@ -873,7 +873,7 @@ packages:
       yoctocolors-cjs: 2.1.2
     dev: true
 
-  /@inquirer/editor@4.2.7(@types/node@22.15.29):
+  /@inquirer/editor@4.2.7(@types/node@24.0.3):
     resolution: {integrity: sha512-gktCSQtnSZHaBytkJKMKEuswSk2cDBuXX5rxGFv306mwHfBPjg5UAldw9zWGoEyvA9KpRDkeM4jfrx0rXn0GyA==}
     engines: {node: '>=18'}
     peerDependencies:
@@ -882,13 +882,13 @@ packages:
       '@types/node':
         optional: true
     dependencies:
-      '@inquirer/core': 10.1.7(@types/node@22.15.29)
-      '@inquirer/type': 3.0.4(@types/node@22.15.29)
-      '@types/node': 22.15.29
+      '@inquirer/core': 10.1.7(@types/node@24.0.3)
+      '@inquirer/type': 3.0.4(@types/node@24.0.3)
+      '@types/node': 24.0.3
       external-editor: 3.1.0
     dev: true
 
-  /@inquirer/expand@4.0.9(@types/node@22.15.29):
+  /@inquirer/expand@4.0.9(@types/node@24.0.3):
     resolution: {integrity: sha512-Xxt6nhomWTAmuSX61kVgglLjMEFGa+7+F6UUtdEUeg7fg4r9vaFttUUKrtkViYYrQBA5Ia1tkOJj2koP9BuLig==}
     engines: {node: '>=18'}
     peerDependencies:
@@ -897,9 +897,9 @@ packages:
       '@types/node':
         optional: true
     dependencies:
-      '@inquirer/core': 10.1.7(@types/node@22.15.29)
-      '@inquirer/type': 3.0.4(@types/node@22.15.29)
-      '@types/node': 22.15.29
+      '@inquirer/core': 10.1.7(@types/node@24.0.3)
+      '@inquirer/type': 3.0.4(@types/node@24.0.3)
+      '@types/node': 24.0.3
       yoctocolors-cjs: 2.1.2
     dev: true
 
@@ -908,7 +908,7 @@ packages:
     engines: {node: '>=18'}
     dev: true
 
-  /@inquirer/input@4.1.6(@types/node@22.15.29):
+  /@inquirer/input@4.1.6(@types/node@24.0.3):
     resolution: {integrity: sha512-1f5AIsZuVjPT4ecA8AwaxDFNHny/tSershP/cTvTDxLdiIGTeILNcKozB0LaYt6mojJLUbOYhpIxicaYf7UKIQ==}
     engines: {node: '>=18'}
     peerDependencies:
@@ -917,12 +917,12 @@ packages:
       '@types/node':
         optional: true
     dependencies:
-      '@inquirer/core': 10.1.7(@types/node@22.15.29)
-      '@inquirer/type': 3.0.4(@types/node@22.15.29)
-      '@types/node': 22.15.29
+      '@inquirer/core': 10.1.7(@types/node@24.0.3)
+      '@inquirer/type': 3.0.4(@types/node@24.0.3)
+      '@types/node': 24.0.3
     dev: true
 
-  /@inquirer/number@3.0.9(@types/node@22.15.29):
+  /@inquirer/number@3.0.9(@types/node@24.0.3):
     resolution: {integrity: sha512-iN2xZvH3tyIYXLXBvlVh0npk1q/aVuKXZo5hj+K3W3D4ngAEq/DkLpofRzx6oebTUhBvOgryZ+rMV0yImKnG3w==}
     engines: {node: '>=18'}
     peerDependencies:
@@ -931,12 +931,12 @@ packages:
       '@types/node':
         optional: true
     dependencies:
-      '@inquirer/core': 10.1.7(@types/node@22.15.29)
-      '@inquirer/type': 3.0.4(@types/node@22.15.29)
-      '@types/node': 22.15.29
+      '@inquirer/core': 10.1.7(@types/node@24.0.3)
+      '@inquirer/type': 3.0.4(@types/node@24.0.3)
+      '@types/node': 24.0.3
     dev: true
 
-  /@inquirer/password@4.0.9(@types/node@22.15.29):
+  /@inquirer/password@4.0.9(@types/node@24.0.3):
     resolution: {integrity: sha512-xBEoOw1XKb0rIN208YU7wM7oJEHhIYkfG7LpTJAEW913GZeaoQerzf5U/LSHI45EVvjAdgNXmXgH51cUXKZcJQ==}
     engines: {node: '>=18'}
     peerDependencies:
@@ -945,13 +945,13 @@ packages:
       '@types/node':
         optional: true
     dependencies:
-      '@inquirer/core': 10.1.7(@types/node@22.15.29)
-      '@inquirer/type': 3.0.4(@types/node@22.15.29)
-      '@types/node': 22.15.29
+      '@inquirer/core': 10.1.7(@types/node@24.0.3)
+      '@inquirer/type': 3.0.4(@types/node@24.0.3)
+      '@types/node': 24.0.3
       ansi-escapes: 4.3.2
     dev: true
 
-  /@inquirer/prompts@7.3.2(@types/node@22.15.29):
+  /@inquirer/prompts@7.3.2(@types/node@24.0.3):
     resolution: {integrity: sha512-G1ytyOoHh5BphmEBxSwALin3n1KGNYB6yImbICcRQdzXfOGbuJ9Jske/Of5Sebk339NSGGNfUshnzK8YWkTPsQ==}
     engines: {node: '>=18'}
     peerDependencies:
@@ -960,20 +960,20 @@ packages:
       '@types/node':
         optional: true
     dependencies:
-      '@inquirer/checkbox': 4.1.2(@types/node@22.15.29)
-      '@inquirer/confirm': 5.1.6(@types/node@22.15.29)
-      '@inquirer/editor': 4.2.7(@types/node@22.15.29)
-      '@inquirer/expand': 4.0.9(@types/node@22.15.29)
-      '@inquirer/input': 4.1.6(@types/node@22.15.29)
-      '@inquirer/number': 3.0.9(@types/node@22.15.29)
-      '@inquirer/password': 4.0.9(@types/node@22.15.29)
-      '@inquirer/rawlist': 4.0.9(@types/node@22.15.29)
-      '@inquirer/search': 3.0.9(@types/node@22.15.29)
-      '@inquirer/select': 4.0.9(@types/node@22.15.29)
-      '@types/node': 22.15.29
+      '@inquirer/checkbox': 4.1.2(@types/node@24.0.3)
+      '@inquirer/confirm': 5.1.6(@types/node@24.0.3)
+      '@inquirer/editor': 4.2.7(@types/node@24.0.3)
+      '@inquirer/expand': 4.0.9(@types/node@24.0.3)
+      '@inquirer/input': 4.1.6(@types/node@24.0.3)
+      '@inquirer/number': 3.0.9(@types/node@24.0.3)
+      '@inquirer/password': 4.0.9(@types/node@24.0.3)
+      '@inquirer/rawlist': 4.0.9(@types/node@24.0.3)
+      '@inquirer/search': 3.0.9(@types/node@24.0.3)
+      '@inquirer/select': 4.0.9(@types/node@24.0.3)
+      '@types/node': 24.0.3
     dev: true
 
-  /@inquirer/rawlist@4.0.9(@types/node@22.15.29):
+  /@inquirer/rawlist@4.0.9(@types/node@24.0.3):
     resolution: {integrity: sha512-+5t6ebehKqgoxV8fXwE49HkSF2Rc9ijNiVGEQZwvbMI61/Q5RcD+jWD6Gs1tKdz5lkI8GRBL31iO0HjGK1bv+A==}
     engines: {node: '>=18'}
     peerDependencies:
@@ -982,13 +982,13 @@ packages:
       '@types/node':
         optional: true
     dependencies:
-      '@inquirer/core': 10.1.7(@types/node@22.15.29)
-      '@inquirer/type': 3.0.4(@types/node@22.15.29)
-      '@types/node': 22.15.29
+      '@inquirer/core': 10.1.7(@types/node@24.0.3)
+      '@inquirer/type': 3.0.4(@types/node@24.0.3)
+      '@types/node': 24.0.3
       yoctocolors-cjs: 2.1.2
     dev: true
 
-  /@inquirer/search@3.0.9(@types/node@22.15.29):
+  /@inquirer/search@3.0.9(@types/node@24.0.3):
     resolution: {integrity: sha512-DWmKztkYo9CvldGBaRMr0ETUHgR86zE6sPDVOHsqz4ISe9o1LuiWfgJk+2r75acFclA93J/lqzhT0dTjCzHuoA==}
     engines: {node: '>=18'}
     peerDependencies:
@@ -997,14 +997,14 @@ packages:
       '@types/node':
         optional: true
     dependencies:
-      '@inquirer/core': 10.1.7(@types/node@22.15.29)
+      '@inquirer/core': 10.1.7(@types/node@24.0.3)
       '@inquirer/figures': 1.0.10
-      '@inquirer/type': 3.0.4(@types/node@22.15.29)
-      '@types/node': 22.15.29
+      '@inquirer/type': 3.0.4(@types/node@24.0.3)
+      '@types/node': 24.0.3
       yoctocolors-cjs: 2.1.2
     dev: true
 
-  /@inquirer/select@4.0.9(@types/node@22.15.29):
+  /@inquirer/select@4.0.9(@types/node@24.0.3):
     resolution: {integrity: sha512-BpJyJe7Dkhv2kz7yG7bPSbJLQuu/rqyNlF1CfiiFeFwouegfH+zh13KDyt6+d9DwucKo7hqM3wKLLyJxZMO+Xg==}
     engines: {node: '>=18'}
     peerDependencies:
@@ -1013,15 +1013,15 @@ packages:
       '@types/node':
         optional: true
     dependencies:
-      '@inquirer/core': 10.1.7(@types/node@22.15.29)
+      '@inquirer/core': 10.1.7(@types/node@24.0.3)
       '@inquirer/figures': 1.0.10
-      '@inquirer/type': 3.0.4(@types/node@22.15.29)
-      '@types/node': 22.15.29
+      '@inquirer/type': 3.0.4(@types/node@24.0.3)
+      '@types/node': 24.0.3
       ansi-escapes: 4.3.2
       yoctocolors-cjs: 2.1.2
     dev: true
 
-  /@inquirer/type@3.0.4(@types/node@22.15.29):
+  /@inquirer/type@3.0.4(@types/node@24.0.3):
     resolution: {integrity: sha512-2MNFrDY8jkFYc9Il9DgLsHhMzuHnOYM1+CUYVWbzu9oT0hC7V7EcYvdCKeoll/Fcci04A+ERZ9wcc7cQ8lTkIA==}
     engines: {node: '>=18'}
     peerDependencies:
@@ -1030,7 +1030,7 @@ packages:
       '@types/node':
         optional: true
     dependencies:
-      '@types/node': 22.15.29
+      '@types/node': 24.0.3
     dev: true
 
   /@isaacs/cliui@8.0.2:
@@ -1075,10 +1075,10 @@ packages:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.0
 
-  /@kinde-oss/kinde-typescript-sdk@2.11.0(eslint@9.24.0)(typescript@5.7.3):
-    resolution: {integrity: sha512-3pSRUAdpM7YecUMpzVano+u1LKnBNwsibBJIpKImW2Fo25Qux5sO+9u/xLy1PEv+L4rt8fXOBF/muRgaxzH1ww==}
+  /@kinde-oss/kinde-typescript-sdk@2.11.1(eslint@9.24.0)(typescript@5.7.3):
+    resolution: {integrity: sha512-jes7NKI4qyYI4XOnq7u4Dfm1gO8f3o7MM+Zy4geg/0A6qz1QV6MvXtM19K0sBbWxPvWIfX+jGRCwnauQKrbe8g==}
     dependencies:
-      '@kinde/js-utils': 0.18.1
+      '@kinde/js-utils': 0.19.0
       '@typescript-eslint/parser': 8.33.1(eslint@9.24.0)(typescript@5.7.3)
       jose: 6.0.11
       uncrypto: 0.1.3
@@ -1100,6 +1100,17 @@ packages:
       '@kinde/jwt-decoder': 0.2.0
     dev: false
 
+  /@kinde/js-utils@0.19.0:
+    resolution: {integrity: sha512-PvbyHxYMkR7Cgc8UG49qXJGGonIsu1MaDkmZRVhhh6Iok7t9tty62k0eCY5EyuN/lWpCG/3/jz6Gb3aAgixzmw==}
+    peerDependencies:
+      expo-secure-store: '>=11.0.0'
+    peerDependenciesMeta:
+      expo-secure-store:
+        optional: true
+    dependencies:
+      '@kinde/jwt-decoder': 0.2.0
+    dev: false
+
   /@kinde/jwt-decoder@0.2.0:
     resolution: {integrity: sha512-dqtwCmAvywOVLkkUfp4UbqdvVLsK0cvHsJhU3gDY9rgjAdZhGw0vCreBW6j3MFLxbi6cZm7pMU7/O5SJgvN5Rw==}
     dev: false
@@ -1111,27 +1122,27 @@ packages:
       jsrsasign: 11.1.0
     dev: false
 
-  /@microsoft/api-extractor-model@7.30.5(@types/node@22.15.29):
+  /@microsoft/api-extractor-model@7.30.5(@types/node@24.0.3):
     resolution: {integrity: sha512-0ic4rcbcDZHz833RaTZWTGu+NpNgrxVNjVaor0ZDUymfDFzjA/Uuk8hYziIUIOEOSTfmIQqyzVwlzxZxPe7tOA==}
     dependencies:
       '@microsoft/tsdoc': 0.15.1
       '@microsoft/tsdoc-config': 0.17.1
-      '@rushstack/node-core-library': 5.13.0(@types/node@22.15.29)
+      '@rushstack/node-core-library': 5.13.0(@types/node@24.0.3)
     transitivePeerDependencies:
       - '@types/node'
     dev: true
 
-  /@microsoft/api-extractor@7.52.3(@types/node@22.15.29):
+  /@microsoft/api-extractor@7.52.3(@types/node@24.0.3):
     resolution: {integrity: sha512-QEs6l8h7p9eOSHrQ9NBBUZhUuq+j/2QKcRgigbSs2YQepKz8glvsqmsUOp+nvuaY60ps7KkpVVYQCj81WLoMVQ==}
     hasBin: true
     dependencies:
-      '@microsoft/api-extractor-model': 7.30.5(@types/node@22.15.29)
+      '@microsoft/api-extractor-model': 7.30.5(@types/node@24.0.3)
       '@microsoft/tsdoc': 0.15.1
       '@microsoft/tsdoc-config': 0.17.1
-      '@rushstack/node-core-library': 5.13.0(@types/node@22.15.29)
+      '@rushstack/node-core-library': 5.13.0(@types/node@24.0.3)
       '@rushstack/rig-package': 0.5.3
-      '@rushstack/terminal': 0.15.2(@types/node@22.15.29)
-      '@rushstack/ts-command-line': 4.23.7(@types/node@22.15.29)
+      '@rushstack/terminal': 0.15.2(@types/node@24.0.3)
+      '@rushstack/ts-command-line': 4.23.7(@types/node@24.0.3)
       lodash: 4.17.21
       minimatch: 3.0.8
       resolve: 1.22.10
@@ -1641,7 +1652,7 @@ packages:
     resolution: {integrity: sha512-kkKUDVlII2DQiKy7UstOR1ErJP8kUKAQ4oa+SQtM0K+lPdmmjj0YnnxBgtTVYH7mUKtbsxeFC9y0AmK7Yb78/A==}
     dev: false
 
-  /@rushstack/node-core-library@5.13.0(@types/node@22.15.29):
+  /@rushstack/node-core-library@5.13.0(@types/node@24.0.3):
     resolution: {integrity: sha512-IGVhy+JgUacAdCGXKUrRhwHMTzqhWwZUI+qEPcdzsb80heOw0QPbhhoVsoiMF7Klp8eYsp7hzpScMXmOa3Uhfg==}
     peerDependencies:
       '@types/node': '*'
@@ -1649,7 +1660,7 @@ packages:
       '@types/node':
         optional: true
     dependencies:
-      '@types/node': 22.15.29
+      '@types/node': 24.0.3
       ajv: 8.13.0
       ajv-draft-04: 1.0.0(ajv@8.13.0)
       ajv-formats: 3.0.1(ajv@8.13.0)
@@ -1667,7 +1678,7 @@ packages:
       strip-json-comments: 3.1.1
     dev: true
 
-  /@rushstack/terminal@0.15.2(@types/node@22.15.29):
+  /@rushstack/terminal@0.15.2(@types/node@24.0.3):
     resolution: {integrity: sha512-7Hmc0ysK5077R/IkLS9hYu0QuNafm+TbZbtYVzCMbeOdMjaRboLKrhryjwZSRJGJzu+TV1ON7qZHeqf58XfLpA==}
     peerDependencies:
       '@types/node': '*'
@@ -1675,15 +1686,15 @@ packages:
       '@types/node':
         optional: true
     dependencies:
-      '@rushstack/node-core-library': 5.13.0(@types/node@22.15.29)
-      '@types/node': 22.15.29
+      '@rushstack/node-core-library': 5.13.0(@types/node@24.0.3)
+      '@types/node': 24.0.3
       supports-color: 8.1.1
     dev: true
 
-  /@rushstack/ts-command-line@4.23.7(@types/node@22.15.29):
+  /@rushstack/ts-command-line@4.23.7(@types/node@24.0.3):
     resolution: {integrity: sha512-Gr9cB7DGe6uz5vq2wdr89WbVDKz0UeuFEn5H2CfWDe7JvjFFaiV15gi6mqDBTbHhHCWS7w8mF1h3BnIfUndqdA==}
     dependencies:
-      '@rushstack/terminal': 0.15.2(@types/node@22.15.29)
+      '@rushstack/terminal': 0.15.2(@types/node@24.0.3)
       '@types/argparse': 1.0.38
       argparse: 1.0.10
       string-argv: 0.3.2
@@ -1809,10 +1820,10 @@ packages:
       undici-types: 6.20.0
     dev: false
 
-  /@types/node@22.15.29:
-    resolution: {integrity: sha512-LNdjOkUDlU1RZb8e1kOIUpN1qQUlzGkEtbVNo53vbrwDg5om6oduhm4SiUaPW5ASTXhAiP0jInWG8Qx9fVlOeQ==}
+  /@types/node@24.0.3:
+    resolution: {integrity: sha512-R4I/kzCYAdRLzfiCabn9hxWfbuHS573x+r0dJMkkzThEa7pbrcDWK+9zu3e7aBOouf+rQAciqPFMnxwr0aWgKg==}
     dependencies:
-      undici-types: 6.21.0
+      undici-types: 7.8.0
     dev: true
 
   /@types/parse-path@7.0.3:
@@ -2043,7 +2054,7 @@ packages:
       '@babel/plugin-transform-react-jsx-source': 7.25.9(@babel/core@7.26.9)
       '@types/babel__core': 7.20.5
       react-refresh: 0.14.2
-      vite: 6.2.5(@types/node@22.15.29)
+      vite: 6.2.5(@types/node@24.0.3)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -2069,7 +2080,7 @@ packages:
       std-env: 3.8.0
       test-exclude: 7.0.1
       tinyrainbow: 2.0.0
-      vitest: 3.0.7(@types/node@22.15.29)(happy-dom@17.1.1)
+      vitest: 3.0.7(@types/node@24.0.3)(happy-dom@17.1.1)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -2097,7 +2108,7 @@ packages:
       '@vitest/spy': 3.0.7
       estree-walker: 3.0.3
       magic-string: 0.30.17
-      vite: 6.2.5(@types/node@22.15.29)
+      vite: 6.2.5(@types/node@24.0.3)
     dev: true
 
   /@vitest/pretty-format@3.0.7:
@@ -4078,16 +4089,16 @@ packages:
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
     dev: true
 
-  /inquirer@12.3.0(@types/node@22.15.29):
+  /inquirer@12.3.0(@types/node@24.0.3):
     resolution: {integrity: sha512-3NixUXq+hM8ezj2wc7wC37b32/rHq1MwNZDYdvx+d6jokOD+r+i8Q4Pkylh9tISYP114A128LCX8RKhopC5RfQ==}
     engines: {node: '>=18'}
     peerDependencies:
       '@types/node': '>=18'
     dependencies:
-      '@inquirer/core': 10.1.7(@types/node@22.15.29)
-      '@inquirer/prompts': 7.3.2(@types/node@22.15.29)
-      '@inquirer/type': 3.0.4(@types/node@22.15.29)
-      '@types/node': 22.15.29
+      '@inquirer/core': 10.1.7(@types/node@24.0.3)
+      '@inquirer/prompts': 7.3.2(@types/node@24.0.3)
+      '@inquirer/type': 3.0.4(@types/node@24.0.3)
+      '@types/node': 24.0.3
       ansi-escapes: 4.3.2
       mute-stream: 2.0.0
       run-async: 3.0.0
@@ -5485,7 +5496,7 @@ packages:
       rc: 1.2.8
     dev: true
 
-  /release-it@18.1.2(@types/node@22.15.29)(typescript@5.7.3):
+  /release-it@18.1.2(@types/node@24.0.3)(typescript@5.7.3):
     resolution: {integrity: sha512-HOVRcicehCgoCsPFOu0iCBlEC8GDOoKS5s6ICkWmqomGEoZtRQ88D3RCsI5MciSU8vAQU+aWZW2z57NQNNb74w==}
     engines: {node: ^20.9.0 || >=22.0.0}
     hasBin: true
@@ -5499,7 +5510,7 @@ packages:
       execa: 9.5.2
       git-url-parse: 16.0.0
       globby: 14.0.2
-      inquirer: 12.3.0(@types/node@22.15.29)
+      inquirer: 12.3.0(@types/node@24.0.3)
       issue-parser: 7.0.1
       lodash: 4.17.21
       mime-types: 2.1.35
@@ -6265,8 +6276,8 @@ packages:
     resolution: {integrity: sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==}
     dev: false
 
-  /undici-types@6.21.0:
-    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+  /undici-types@7.8.0:
+    resolution: {integrity: sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==}
     dev: true
 
   /undici@6.21.1:
@@ -6329,7 +6340,7 @@ packages:
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     dev: true
 
-  /vite-node@3.0.7(@types/node@22.15.29):
+  /vite-node@3.0.7(@types/node@24.0.3):
     resolution: {integrity: sha512-2fX0QwX4GkkkpULXdT1Pf4q0tC1i1lFOyseKoonavXUNlQ77KpW2XqBGGNIm/J4Ows4KxgGJzDguYVPKwG/n5A==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
@@ -6338,7 +6349,7 @@ packages:
       debug: 4.4.0
       es-module-lexer: 1.6.0
       pathe: 2.0.3
-      vite: 6.2.5(@types/node@22.15.29)
+      vite: 6.2.5(@types/node@24.0.3)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -6354,7 +6365,7 @@ packages:
       - yaml
     dev: true
 
-  /vite-plugin-dts@4.5.3(@types/node@22.15.29)(rollup@4.34.8)(typescript@5.7.3)(vite@6.2.5):
+  /vite-plugin-dts@4.5.3(@types/node@24.0.3)(rollup@4.34.8)(typescript@5.7.3)(vite@6.2.5):
     resolution: {integrity: sha512-P64VnD00dR+e8S26ESoFELqc17+w7pKkwlBpgXteOljFyT0zDwD8hH4zXp49M/kciy//7ZbVXIwQCekBJjfWzA==}
     peerDependencies:
       typescript: '*'
@@ -6363,7 +6374,7 @@ packages:
       vite:
         optional: true
     dependencies:
-      '@microsoft/api-extractor': 7.52.3(@types/node@22.15.29)
+      '@microsoft/api-extractor': 7.52.3(@types/node@24.0.3)
       '@rollup/pluginutils': 5.1.4(rollup@4.34.8)
       '@volar/typescript': 2.4.12
       '@vue/language-core': 2.2.0(typescript@5.7.3)
@@ -6373,14 +6384,14 @@ packages:
       local-pkg: 1.1.1
       magic-string: 0.30.17
       typescript: 5.7.3
-      vite: 6.2.5(@types/node@22.15.29)
+      vite: 6.2.5(@types/node@24.0.3)
     transitivePeerDependencies:
       - '@types/node'
       - rollup
       - supports-color
     dev: true
 
-  /vite@6.2.5(@types/node@22.15.29):
+  /vite@6.2.5(@types/node@24.0.3):
     resolution: {integrity: sha512-j023J/hCAa4pRIUH6J9HemwYfjB5llR2Ps0CWeikOtdR8+pAURAk0DoJC5/mm9kd+UgdnIy7d6HE4EAvlYhPhA==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
@@ -6420,7 +6431,7 @@ packages:
       yaml:
         optional: true
     dependencies:
-      '@types/node': 22.15.29
+      '@types/node': 24.0.3
       esbuild: 0.25.2
       postcss: 8.5.3
       rollup: 4.34.8
@@ -6428,7 +6439,7 @@ packages:
       fsevents: 2.3.3
     dev: true
 
-  /vitest@3.0.7(@types/node@22.15.29)(happy-dom@17.1.1):
+  /vitest@3.0.7(@types/node@24.0.3)(happy-dom@17.1.1):
     resolution: {integrity: sha512-IP7gPK3LS3Fvn44x30X1dM9vtawm0aesAa2yBIZ9vQf+qB69NXC5776+Qmcr7ohUXIQuLhk7xQR0aSUIDPqavg==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
@@ -6456,7 +6467,7 @@ packages:
       jsdom:
         optional: true
     dependencies:
-      '@types/node': 22.15.29
+      '@types/node': 24.0.3
       '@vitest/expect': 3.0.7
       '@vitest/mocker': 3.0.7(vite@6.2.5)
       '@vitest/pretty-format': 3.0.7
@@ -6475,8 +6486,8 @@ packages:
       tinyexec: 0.3.2
       tinypool: 1.0.2
       tinyrainbow: 2.0.0
-      vite: 6.2.5(@types/node@22.15.29)
-      vite-node: 3.0.7(@types/node@22.15.29)
+      vite: 6.2.5(@types/node@24.0.3)
+      vite-node: 3.0.7(@types/node@24.0.3)
       why-is-node-running: 2.3.0
     transitivePeerDependencies:
       - jiti


### PR DESCRIPTION
# Explain your changes

Updated TS SDK which includes update to prevent build tool from trying to import expo-secure-store.

fixes: #347

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
