### PR TITLE
fix: preserve url search params in `withAuth` middleware

### DIFF
--- a/src/authMiddleware/authMiddleware.ts
+++ b/src/authMiddleware/authMiddleware.ts
@@ -14,7 +14,7 @@ import { getStandardCookieOptions } from "../utils/cookies/getStandardCookieOpti
 import { isPublicPathMatch } from "../utils/isPublicPathMatch";
 
 const handleMiddleware = async (req, options, onSuccess) => {
-  const { pathname } = req.nextUrl;
+  const { pathname, search } = req.nextUrl;
 
   const isReturnToCurrentPage = options?.isReturnToCurrentPage;
   const orgCode: string | undefined = options?.orgCode;
@@ -46,7 +46,7 @@ const handleMiddleware = async (req, options, onSuccess) => {
   }
 
   if (isReturnToCurrentPage) {
-    loginRedirectUrlParams.set("post_login_redirect_url", pathname);
+    loginRedirectUrlParams.set("post_login_redirect_url", pathname + search);
   }
 
   const queryString = loginRedirectUrlParams.toString();
@@ -59,7 +59,7 @@ const handleMiddleware = async (req, options, onSuccess) => {
   const isPublicPath = isPublicPathMatch(
     pathname,
     publicPaths,
-    config.isDebugMode,
+    config.isDebugMode
   );
 
   // getAccessToken will validate the token
@@ -71,11 +71,11 @@ const handleMiddleware = async (req, options, onSuccess) => {
   if ((!kindeAccessToken || !kindeIdToken) && !isPublicPath) {
     if (config.isDebugMode) {
       console.log(
-        "authMiddleware: no access or id token, redirecting to login",
+        "authMiddleware: no access or id token, redirecting to login"
       );
     }
     return NextResponse.redirect(
-      new URL(loginRedirectUrl, options?.redirectURLBase || config.redirectURL),
+      new URL(loginRedirectUrl, options?.redirectURLBase || config.redirectURL)
     );
   }
 
@@ -97,8 +97,8 @@ const handleMiddleware = async (req, options, onSuccess) => {
         return NextResponse.redirect(
           new URL(
             loginRedirectUrl,
-            options?.redirectURLBase || config.redirectURL,
-          ),
+            options?.redirectURLBase || config.redirectURL
+          )
         );
       }
       return undefined;
@@ -112,7 +112,7 @@ const handleMiddleware = async (req, options, onSuccess) => {
         console.log(
           "authMiddleware: tokens refreshed",
           !!refreshResponse.access_token,
-          !!refreshResponse.id_token,
+          !!refreshResponse.id_token
         );
       }
     } catch (error) {
@@ -125,7 +125,7 @@ const handleMiddleware = async (req, options, onSuccess) => {
       // we need to set the cookie on the response here
       const splitAccessTokenCookies = getSplitCookies(
         "access_token",
-        refreshResponse.access_token,
+        refreshResponse.access_token
       );
       splitAccessTokenCookies.forEach((cookie) => {
         resp.cookies.set(cookie.name, cookie.value, cookie.options);
@@ -133,7 +133,7 @@ const handleMiddleware = async (req, options, onSuccess) => {
 
       const splitIdTokenCookies = getSplitCookies(
         "id_token",
-        refreshResponse.id_token,
+        refreshResponse.id_token
       );
       splitIdTokenCookies.forEach((cookie) => {
         resp.cookies.set(cookie.name, cookie.value, cookie.options);
@@ -142,7 +142,7 @@ const handleMiddleware = async (req, options, onSuccess) => {
       resp.cookies.set(
         "refresh_token",
         refreshResponse.refresh_token,
-        getStandardCookieOptions(),
+        getStandardCookieOptions()
       );
 
       // copy the cookies from the response to the request
@@ -156,7 +156,7 @@ const handleMiddleware = async (req, options, onSuccess) => {
       }
     } catch (error) {
       const result = sendResult(
-        "authMiddleware: error settings new token in cookie",
+        "authMiddleware: error settings new token in cookie"
       );
       if (result) return result;
     }
@@ -176,11 +176,11 @@ const handleMiddleware = async (req, options, onSuccess) => {
   } catch (error) {
     if (config.isDebugMode) {
       console.error(
-        "authMiddleware: access token decode failed, redirecting to login",
+        "authMiddleware: access token decode failed, redirecting to login"
       );
     }
     return NextResponse.redirect(
-      new URL(loginRedirectUrl, options?.redirectURLBase || config.redirectURL),
+      new URL(loginRedirectUrl, options?.redirectURLBase || config.redirectURL)
     );
   }
 
@@ -189,11 +189,11 @@ const handleMiddleware = async (req, options, onSuccess) => {
   } catch (error) {
     if (config.isDebugMode) {
       console.error(
-        "authMiddleware: id token decode failed, redirecting to login",
+        "authMiddleware: id token decode failed, redirecting to login"
       );
     }
     return NextResponse.redirect(
-      new URL(loginRedirectUrl, options?.redirectURLBase || config.redirectURL),
+      new URL(loginRedirectUrl, options?.redirectURLBase || config.redirectURL)
     );
   }
 
@@ -220,7 +220,7 @@ const handleMiddleware = async (req, options, onSuccess) => {
     if (callbackResult instanceof NextResponse) {
       if (config.isDebugMode) {
         console.log(
-          "authMiddleware: onSuccess callback returned a response, copying our cookies to it",
+          "authMiddleware: onSuccess callback returned a response, copying our cookies to it"
         );
       }
       // Copy our cookies to their response
@@ -241,7 +241,7 @@ const handleMiddleware = async (req, options, onSuccess) => {
     // If they didn't return a response, return our response with the refreshed tokens
     if (config.isDebugMode) {
       console.log(
-        "authMiddleware: onSuccess callback did not return a response, returning our response",
+        "authMiddleware: onSuccess callback did not return a response, returning our response"
       );
     }
 
@@ -251,7 +251,7 @@ const handleMiddleware = async (req, options, onSuccess) => {
   if (customValidationValid) {
     if (config.isDebugMode) {
       console.log(
-        "authMiddleware: customValidationValid is true, returning response",
+        "authMiddleware: customValidationValid is true, returning response"
       );
     }
     return resp;
@@ -262,7 +262,7 @@ const handleMiddleware = async (req, options, onSuccess) => {
   }
 
   return NextResponse.redirect(
-    new URL(loginRedirectUrl, options?.redirectURLBase || config.redirectURL),
+    new URL(loginRedirectUrl, options?.redirectURLBase || config.redirectURL)
   );
 };
 


### PR DESCRIPTION
# Explain your changes

**The Problem:**  
In earlier versions, if a user tried to access a protected page with search parameters (for example, `/dashboard?tab=settings&id=123`), the `withAuth` middleware would redirect them to the login page. After they logged in successfully, they would be sent back to `/dashboard`. However, the `?tab=settings&id=123` section of the URL would be missing. This meant users were not returning to the exact page or state they expected, often causing extra clicks or confusion.

**The Fix:**  
This commit adds a solution that ensures `withAuth` now preserves all search parameters during the login redirection. Users will now return to the exact URL they were trying to access, including any query strings. So, `/dashboard?tab=settings&id=123` will properly return them to `/dashboard?tab=settings&id=123` after they log in.

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
