### PR TITLE
fix: prefetch skipped error preventing user access

### DIFF
--- a/src/handlers/createOrg.ts
+++ b/src/handlers/createOrg.ts
@@ -10,7 +10,7 @@ import { isPreFetch } from "../utils/isPreFetch";
 export const createOrg = async (routerClient: RouterClient) => {
   const headers = await getHeaders(routerClient.req);
   if (isPreFetch(headers)) {
-    return routerClient.json({ message: "Prefetch skipped" }, { status: 200 });
+    return null;
   }
 
   const org_name = routerClient.getSearchParam("org_name");

--- a/src/handlers/login.ts
+++ b/src/handlers/login.ts
@@ -10,7 +10,7 @@ import validateState from "../utils/validateState";
 export const login = async (routerClient: RouterClient) => {
   const headers = await getHeaders(routerClient.req);
   if (isPreFetch(headers)) {
-    return routerClient.json({ message: "Prefetch skipped" }, { status: 200 });
+    return null;
   }
 
   const passedState = routerClient.searchParams.get("state");

--- a/src/handlers/logout.ts
+++ b/src/handlers/logout.ts
@@ -10,7 +10,7 @@ import { getHeaders } from "../utils/getHeaders";
 export const logout = async (routerClient: RouterClient) => {
   const headers = await getHeaders(routerClient.req);
   if (isPreFetch(headers)) {
-    return routerClient.json({ message: "Prefetch skipped" }, { status: 200 });
+    return null;
   }
 
   const authUrl = await routerClient.kindeClient.logout(

--- a/src/handlers/portal.ts
+++ b/src/handlers/portal.ts
@@ -18,7 +18,7 @@ import { config, routes } from "../config";
 export const portal = async (routerClient: RouterClient) => {
   const headers = await getHeaders(routerClient.req);
   if (isPreFetch(headers)) {
-    return routerClient.json({ message: "Prefetch skipped" }, { status: 200 });
+    return null;
   }
 
   const storage = new MemoryStorage();

--- a/src/handlers/register.ts
+++ b/src/handlers/register.ts
@@ -10,7 +10,7 @@ import validateState from "../utils/validateState";
 export const register = async (routerClient: RouterClient) => {
   const headers = await getHeaders(routerClient.req);
   if (isPreFetch(headers)) {
-    return routerClient.json({ message: "Prefetch skipped" }, { status: 200 });
+    return null;
   }
 
   const authUrl = await routerClient.kindeClient.register(


### PR DESCRIPTION
# Explain your changes
replaced prefetch skipped 200 with null as returning the 200 causes it to appear for users and prevented further access. 

Replaced in :
- createOrg.ts
- login.ts
- logout.ts
- portal.ts
- register.ts

Testing:
Validating that each of these components still works when the value for the isPreFetch check was rather difficult as there were not any clear reproduction steps that I could find. 

# Checklist

- [X] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [X] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
