### PR TITLE
fix: setup enqueue and processQueue logs to only appear when isDebugMode true

### DIFF
--- a/src/utils/workQueue.ts
+++ b/src/utils/workQueue.ts
@@ -1,3 +1,5 @@
+import { config } from "../config/index";
+
 type QueueItem = {
   execute: () => Promise<any>;
   resolve: (value: any) => void;
@@ -20,7 +22,9 @@ export class RequestQueueManager {
 
   async enqueue<T>(task: () => Promise<T>): Promise<T> {
     return new Promise((resolve, reject) => {
-      console.debug("enqueue: task added to queue");
+      if (config.isDebugMode) {
+        console.debug("enqueue: task added to queue");
+      }
       this.queue.push({
         execute: task,
         resolve,
@@ -38,7 +42,9 @@ export class RequestQueueManager {
 
     try {
       const result = await item.execute();
-      console.debug("processQueue: task executed successfully");
+      if (config.isDebugMode) {
+        console.debug("processQueue: task executed successfully");
+      }
       item.resolve(result);
     } catch (error) {
       console.debug("processQueue: task execution failed", error);


### PR DESCRIPTION
# Explain your changes
setup enqueue and processQueue logs to only appear when isDebugMode true. Make use of `KINDE_DEBUG_MODE` .env variable to allow these console.debug messages to be hidden for users.

Fixes #376 

# Checklist

- [X] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [X] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
