### PR TITLE
fix: pages router token refresh by passing both req and res to sessionManager

### DIFF
--- a/src/handlers/setup.ts
+++ b/src/handlers/setup.ts
@@ -35,7 +35,7 @@ export const setup = async (routerClient: RouterClient) => {
         );
       }
 
-      const session = await sessionManager(routerClient.req);
+      const session = await sessionManager(routerClient.req, routerClient.res);
 
       if (
         isTokenExpired(accessTokenEncoded) ||


### PR DESCRIPTION
# Explain your changes

Token refresh was failing on subsequent attempts in Pages Router because the session manager wasn't receiving the response object needed to set cookies.

# Checklist

- [x] I have read the ["Pull requests" section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
