### PR TITLE
chore: update setup handler error handling to display error message

### DIFF
--- a/src/handlers/setup.ts
+++ b/src/handlers/setup.ts
@@ -53,9 +53,9 @@ export const setup = async (routerClient: RouterClient) => {
             console.error("setup: refresh tokens failed - returning error");
           }
           return routerClient.json(
-            { 
-              message: "REFRESH_FAILED", 
-              error: error instanceof Error ? error.message : error 
+            {
+              message: "REFRESH_FAILED",
+              error: error instanceof Error ? error.message : error,
             },
             { status: 500 },
           );
@@ -74,9 +74,9 @@ export const setup = async (routerClient: RouterClient) => {
           );
         }
         return routerClient.json(
-          { 
-            message: "ACCESS_TOKEN_DECODE_FAILED", 
-            error: error instanceof Error ? error.message : error 
+          {
+            message: "ACCESS_TOKEN_DECODE_FAILED",
+            error: error instanceof Error ? error.message : error,
           },
           { status: 500 },
         );
@@ -89,9 +89,9 @@ export const setup = async (routerClient: RouterClient) => {
           console.error("setup: id token decode failed, redirecting to login");
         }
         return routerClient.json(
-          { 
-            message: "ID_TOKEN_DECODE_FAILED", 
-            error: error instanceof Error ? error.message : error 
+          {
+            message: "ID_TOKEN_DECODE_FAILED",
+            error: error instanceof Error ? error.message : error,
           },
           { status: 500 },
         );


### PR DESCRIPTION
# Explain your changes

Updated the error handling in setup handler to display the error message. currently error objects are serializing as empty `{}` instead of showing actual error messages.


# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
