### PR TITLE
chore(deps): update prettier to 3.8.2 and fix formatting

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "genversion": "^3.2.0",
     "globals": "^16.0.0",
     "happy-dom": "^20.8.9",
-    "prettier": "^3.4.2",
+    "prettier": "^3.8.2",
     "release-it": "^19.0.0",
     "rollup-plugin-preserve-directives": "^0.4.0",
     "typescript": "^5.7.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -85,8 +85,8 @@ importers:
         specifier: ^20.8.9
         version: 20.8.9
       prettier:
-        specifier: ^3.4.2
-        version: 3.6.2
+        specifier: ^3.8.2
+        version: 3.8.2
       release-it:
         specifier: ^19.0.0
         version: 19.0.5(@types/node@25.6.0)(magicast@0.3.5)
@@ -3002,8 +3002,8 @@ packages:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
 
-  prettier@3.6.2:
-    resolution: {integrity: sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==}
+  prettier@3.8.2:
+    resolution: {integrity: sha512-8c3mgTe0ASwWAJK+78dpviD+A8EqhndQPUBpNUIPt6+xWlIigCwfN01lWr9MAede4uqXGTEKeQWTvzb3vjia0Q==}
     engines: {node: '>=14'}
     hasBin: true
 
@@ -6655,7 +6655,7 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
-  prettier@3.6.2: {}
+  prettier@3.8.2: {}
 
   pretty-format@27.5.1:
     dependencies:

--- a/src/components/PortalLink.tsx
+++ b/src/components/PortalLink.tsx
@@ -3,7 +3,8 @@ import { config, routes } from "../config/index";
 import { GeneratePortalUrlParams } from "@kinde-oss/kinde-auth-react/utils";
 
 export interface PortalLinkProps
-  extends React.AnchorHTMLAttributes<HTMLAnchorElement>,
+  extends
+    React.AnchorHTMLAttributes<HTMLAnchorElement>,
     Partial<Omit<GeneratePortalUrlParams, "domain">> {
   children: React.ReactNode;
 }

--- a/src/frontend/utils.ts
+++ b/src/frontend/utils.ts
@@ -3,9 +3,8 @@ import { FetchedKindeState, PublicKindeConfig } from "./types.js";
 
 export const getRefreshTokensServerAction = async () => {
   try {
-    const { refreshTokensServerAction } = await import(
-      "../session/refreshTokensServerAction.js"
-    );
+    const { refreshTokensServerAction } =
+      await import("../session/refreshTokensServerAction.js");
     return refreshTokensServerAction;
   } catch (error) {
     return null;


### PR DESCRIPTION
Addresses the same issue as #460, which fails CI due to prettier formatting violations.

## What changed
- Bumped `prettier` from `^3.4.2` → `^3.8.2` in `package.json`
- Updated `pnpm-lock.yaml` to resolve prettier 3.8.2
- Re-formatted `src/components/PortalLink.tsx` - prettier 3.8.x reformats multi-item `extends` clauses
- Re-formatted `src/frontend/utils.ts` - minor whitespace adjustments per 3.8.x rules

## Why this instead of #460
PR #460 (Renovate) only updates the lockfile but doesn't re-format the source files to match the new prettier rules, causing `pnpm lint` (`prettier --check .`) to fail with exit code 1 on those two files. This PR includes the lockfile update **and** the necessary source file reformats so the build passes.