### PR TITLE
chore(ci): update actions/cache to v5

### DIFF
--- a/.github/workflows/build-test-ci.yml
+++ b/.github/workflows/build-test-ci.yml
@@ -26,7 +26,7 @@ jobs:
       - run: pnpm install
       - run: pnpm lint
       - name: Cache pnpm modules
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.pnpm-store
           key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}


### PR DESCRIPTION
Addresses the same change as #462, which targets a protected branch.

## What changed
Single line in `.github/workflows/build-test-ci.yml`: `actions/cache@v4` → `actions/cache@v5`

## Why it's safe
- The only breaking change in v5 vs v4 is the action's internal runtime upgrade from Node.js 20 → Node.js 24, requiring runner ≥ `2.327.1`
- `ubuntu-latest` (GitHub-hosted) is always up to date — this requirement is automatically satisfied
- The `with:` block (`path`, `key`, `restore-keys`) is fully compatible with v5 — no input changes needed
- Zero impact on SDK code, npm packages, lockfile, or anything shipped to consumers