### PR TITLE
chore(deps): update dependency globals to v16.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "eslint": "^9.22.0",
     "eslint-config-prettier": "^10.0.1",
     "genversion": "^3.2.0",
-    "globals": "^16.0.0",
+    "globals": "^16.5.0",
     "happy-dom": "^20.8.9",
     "prettier": "^3.4.2",
     "release-it": "^19.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -79,8 +79,8 @@ importers:
         specifier: ^3.2.0
         version: 3.2.0
       globals:
-        specifier: ^16.0.0
-        version: 16.4.0
+        specifier: ^16.5.0
+        version: 16.5.0
       happy-dom:
         specifier: ^20.8.9
         version: 20.8.9
@@ -2271,6 +2271,10 @@ packages:
 
   globals@16.4.0:
     resolution: {integrity: sha512-ob/2LcVVaVGCYN+r14cnwnoDPUufjiYgSqRhiFD0Q1iI4Odora5RE8Iv1D24hAz5oMophRGkGz+yuvQmmUMnMw==}
+    engines: {node: '>=18'}
+
+  globals@16.5.0:
+    resolution: {integrity: sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ==}
     engines: {node: '>=18'}
 
   globalthis@1.0.4:
@@ -5913,6 +5917,8 @@ snapshots:
   globals@14.0.0: {}
 
   globals@16.4.0: {}
+
+  globals@16.5.0: {}
 
   globalthis@1.0.4:
     dependencies:


### PR DESCRIPTION
## Summary

Updates `globals` from `16.4.0` → `16.5.0` with a clean, conflict-free lockfile.

## Why this PR?

PR [#419](https://github.com/kinde-oss/kinde-auth-nextjs/pull/419) (created by Renovate) addresses the same update but has lockfile conflicts that Renovate is unable to resolve on a protected branch. This PR resolves the issue manually from a fresh `main` baseline.

## Changes

- `package.json`: bumped `globals` constraint from `^16.0.0` → `^16.5.0`
- `pnpm-lock.yaml`: updated resolved version for `globals` from `16.4.0` → `16.5.0`

## Verification

`pnpm install --frozen-lockfile` passes cleanly.

## globals v16.5.0 release notes

- Add Vue, Svelte, and Astro globals ([sindresorhus/globals#314](https://github.com/sindresorhus/globals/issues/314))
- Update globals (2025-11-01) ([sindresorhus/globals#316](https://github.com/sindresorhus/globals/issues/316))