### PR TITLE
chore(deps): update dependency @testing-library/react to v16.3.2

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,7 +50,7 @@ importers:
         version: 9.36.0
       '@testing-library/react':
         specifier: ^16.2.0
-        version: 16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@19.2.0(@types/react@19.2.0))(@types/react@19.2.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.0(@types/react@19.2.0))(@types/react@19.2.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@types/react':
         specifier: ^19.0.8
         version: 19.2.0
@@ -1187,8 +1187,8 @@ packages:
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
     engines: {node: '>=18'}
 
-  '@testing-library/react@16.3.0':
-    resolution: {integrity: sha512-kFSyxiEDwv1WLl2fgsq6pPBbw5aWKrsY2/noi1Id0TK0UParSF62oFQFGHXIyaG4pp2tEub/Zlel+fjjZILDsw==}
+  '@testing-library/react@16.3.2':
+    resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
     engines: {node: '>=18'}
     peerDependencies:
       '@testing-library/dom': ^10.0.0
@@ -4560,7 +4560,7 @@ snapshots:
       picocolors: 1.1.1
       pretty-format: 27.5.1
 
-  '@testing-library/react@16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@19.2.0(@types/react@19.2.0))(@types/react@19.2.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.0(@types/react@19.2.0))(@types/react@19.2.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
       '@babel/runtime': 7.28.4
       '@testing-library/dom': 10.4.1


### PR DESCRIPTION
## Summary

Updates `@testing-library/react` from `16.3.0` → `16.3.2` with a clean, conflict-free lockfile.

## Why this PR?

PR [#451](https://github.com/kinde-oss/kinde-auth-nextjs/pull/451) (created by Renovate) addresses the same update but has lockfile conflicts that Renovate is unable to resolve on a protected `main` branch. This PR resolves the issue manually from a fresh `main` baseline.

## Changes

- `pnpm-lock.yaml`: updated resolved version for `@testing-library/react` from `16.3.0` → `16.3.2` (minor patch bumps, lockfile-only change)

## Verification

`pnpm install --frozen-lockfile` passes cleanly.

## @testing-library/react v16.3.2 release notes

- [v16.3.2](https://github.com/testing-library/react-testing-library/compare/v16.3.1...f32bd1b033d5e3989ae1cb490d515ce389c54e53) - patch release
- [v16.3.1](https://github.com/testing-library/react-testing-library/compare/v16.3.0...a2d37ffa09d85b10485f29b79cf7cb4f8ec943db) - patch release