### PR TITLE
[FIX] correct CJS export of handleAuth with preserveModules

### DIFF
--- a/src/server/index.js
+++ b/src/server/index.js
@@ -7,5 +7,6 @@ export {
   RegisterLink,
 } from "../components/index";
 export { createKindeManagementAPIClient } from "../api-client";
-export { default as handleAuth } from "../handlers/auth";
+import _handleAuth from "../handlers/auth";
+export const handleAuth = (...args) => _handleAuth(...args);
 export { protectPage, protectApi } from "../handlers/protect";


### PR DESCRIPTION
# Explain your changes
## Problem

When consuming `@kinde-oss/kinde-auth-nextjs/server` via the CJS bundle (e.g. Next.js pages router with webpack), `handleAuth` is `undefined` at runtime. This causes a 500 error on all `/api/auth/*` routes because calling `handleAuth()` throws `TypeError: handleAuth is not a function`.

The root cause is in rolldown's `preserveModules: true` CJS output. The original `server/index.js` re-exported the default as a named export:

```js
export { default as handleAuth } from "../handlers/auth";
```

Rolldown incorrectly compiles this to:

```js
const s = require('./src/handlers/auth.cjs.js');
exports.handleAuth = s; // ← module namespace object, not the function
```

Instead of the correct:

```js
exports.handleAuth = s.default; // ← the actual function
```

This is a rolldown bug (Vite 8.x uses rolldown v1.0.0-rc.17). ESM consumers (Turbopack) are unaffected because the ESM bundle handles named re-exports correctly.

## Fix

Introduce a local binding in `server/index.js` that forces rolldown to generate a proper CJS export:

```js
import _handleAuth from "../handlers/auth";
export const handleAuth = (...args) => _handleAuth(...args);
```

This produces the correct CJS output:

```js
var l = (...e) => s.default(...e);
exports.handleAuth = l; // ← function reference ✓
```

## Trade-off: tree-shaking

The wrapper breaks static re-export tracing for `handleAuth` — bundlers can no longer see through it as a live binding. The proper fix would be to use separate rollup output configs: `preserveModules: true` for the ESM build (tree-shakable) and a standard bundled output for CJS (where tree-shaking doesn't apply anyway). However, since `handleAuth` lives in a server-only subpath entry (`/server`), the practical tree-shaking impact is negligible.

The root issue should be filed against rolldown: named CJS exports are not emitted for `export const` declarations within modules when `preserveModules: true` is set.

## Testing

Verified against a Next.js 16 pages router project (`next dev --webpack`): `/api/auth/setup` returns 200 after this fix vs 500 before.



# Checklist

- [X] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [X] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
