### PR TITLE
fix: resolve CJS bundle incorrectly exporting handleAuth and getKindeServerSession

### DIFF
--- a/src/handlers/auth.js
+++ b/src/handlers/auth.js
@@ -41,7 +41,7 @@ const getRoute = (endpoint) => {
  * @param {{onError?: () => void; config: {audience?: string | string[], clientId?: string, clientSecret?: string, issuerURL?: string, siteUrl?: string, postLoginRedirectUrl?: string, postLogoutRedirectUrl?: string}}} [options]
  * @returns {(req, res) => any}
  */
-export default (request, endpoint, options) => {
+export const handleAuth = (request, endpoint, options) => {
   if (!config.clientOptions.authDomain)
     throw new Error(
       "The environment variable 'KINDE_ISSUER_URL' is required. Set it in your .env file",

--- a/src/handlers/protect.js
+++ b/src/handlers/protect.js
@@ -1,4 +1,4 @@
-import kinde from "../session/index";
+import { getKindeServerSession as kinde } from "../session/index";
 import { redirect } from "next/navigation";
 import { NextResponse } from "next/server";
 import { routes } from "../config";

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -1,4 +1,4 @@
-export { default as getKindeServerSession } from "../session/index.ts";
+export { getKindeServerSession } from "../session/index.ts";
 export { withAuth } from "../authMiddleware/authMiddleware";
 export {
   LoginLink,
@@ -7,5 +7,5 @@ export {
   RegisterLink,
 } from "../components/index";
 export { createKindeManagementAPIClient } from "../api-client";
-export { default as handleAuth } from "../handlers/auth";
+export { handleAuth } from "../handlers/auth";
 export { protectPage, protectApi } from "../handlers/protect";

--- a/src/session/index.ts
+++ b/src/session/index.ts
@@ -111,4 +111,4 @@ const sessionHandler = (
   };
 };
 
-export default sessionHandler;
+export { sessionHandler as getKindeServerSession };


### PR DESCRIPTION
## Problem

Since v2.12.1, webpack users (e.g. `next dev --webpack`) get a 500 on `/api/auth/setup` with:

```
handleAuth is not a function
```

The CJS bundle (`dist/server.cjs.js`) exports `handleAuth` and `getKindeServerSession` as module objects (`{ default: fn }`) rather than the functions themselves. ESM consumers are unaffected because `import` properly resolves the default.

Reproduced via https://github.com/abdelrahman-zaki/kinde-nextjs-pages-router.

## Root cause

Our Vite build uses `preserveModules: true` in the Rollup output config (needed for `"use client"` directive preservation). When an entry file re-exports a default export:

```js
export { default as handleAuth } from "../handlers/auth";
```

Rollup generates correct ESM (`import x from ... ; export { x as handleAuth }`), but in CJS it emits:

```js
const s = require("./src/handlers/auth.cjs.js");
exports.handleAuth = s; // ← whole module object, not s.default
```

This is a known gap in Rollup's `preserveModules` + CJS interop for `export { default as ... }` patterns.

## Fix

Convert the affected default exports to named exports at the source level. This way the CJS output correctly uses property access:

```js
exports.handleAuth = s.handleAuth;           // ✓ function
exports.getKindeServerSession = i.sessionHandler; // ✓ function
```

No runtime wrappers, no build config workarounds - just aligning the source exports to what Rollup handles correctly in both formats.

## Changes

- `src/handlers/auth.js` - `export default` → `export const handleAuth`
- `src/session/index.ts` - `export default sessionHandler` → `export { sessionHandler as getKindeServerSession }`
- `src/server/index.js` - `export { default as X }` → `export { X }`
- `src/handlers/protect.js` - updated internal import to use named export

## Verification

- `pnpm build` passes
- All 34 existing tests pass
- Runtime check confirms both exports are `typeof === 'function'` in CJS

Related: #505