### PR TITLE
fix: keep isLoading true when isAuthenticated but user not yet decoded

### DIFF
--- a/src/frontend/factories/index.test.ts
+++ b/src/frontend/factories/index.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { transformReactAuthStateToNextState, constructKindeClientState } from "./index";
+import {
+  transformReactAuthStateToNextState,
+  constructKindeClientState,
+} from "./index";
 import type { KindeContextProps } from "@kinde-oss/kinde-auth-react";
 
 // ---------------------------------------------------------------------------
@@ -108,7 +111,10 @@ describe("transformReactAuthStateToNextState — isLoading correctness", () => {
 
   // ── Scenario 1: React SDK still loading ──────────────────────────────────
   it("returns isLoading true when reactAuthState.isLoading is true", async () => {
-    const reactAuth = makeReactAuth({ isLoading: true, isAuthenticated: false });
+    const reactAuth = makeReactAuth({
+      isLoading: true,
+      isAuthenticated: false,
+    });
 
     const result = await transformReactAuthStateToNextState(reactAuth);
 
@@ -159,7 +165,7 @@ describe("transformReactAuthStateToNextState — isLoading correctness", () => {
   it("returns isLoading false with user when authenticated and tokens decoded", async () => {
     mockJwtDecoder
       .mockReturnValueOnce(DECODED_ACCESS_TOKEN) // first call → accessToken
-      .mockReturnValueOnce(DECODED_ID_TOKEN);    // second call → idToken
+      .mockReturnValueOnce(DECODED_ID_TOKEN); // second call → idToken
 
     const reactAuth = makeReactAuth({
       isLoading: false,

--- a/src/frontend/factories/index.test.ts
+++ b/src/frontend/factories/index.test.ts
@@ -1,0 +1,294 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { transformReactAuthStateToNextState, constructKindeClientState } from "./index";
+import type { KindeContextProps } from "@kinde-oss/kinde-auth-react";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock("@kinde/jwt-decoder", () => ({
+  jwtDecoder: vi.fn(),
+}));
+
+vi.mock("../../utils/generateUserObject", () => ({
+  generateUserObject: vi.fn(() => ({
+    id: "user_01",
+    email: "jane@example.com",
+    given_name: "Jane",
+    family_name: "Doe",
+    picture: null,
+    username: null,
+    phone_number: null,
+  })),
+}));
+
+import { jwtDecoder } from "@kinde/jwt-decoder";
+import { generateUserObject } from "../../utils/generateUserObject";
+
+const mockJwtDecoder = vi.mocked(jwtDecoder);
+const mockGenerateUserObject = vi.mocked(generateUserObject);
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const DECODED_ACCESS_TOKEN = {
+  permissions: ["read:data"],
+  org_code: "org_01",
+  org_name: "Acme",
+  feature_flags: { dark_mode: { v: true, t: "b" } },
+  organization_properties: {},
+};
+
+const DECODED_ID_TOKEN = {
+  sub: "user_01",
+  email: "jane@example.com",
+  given_name: "Jane",
+  family_name: "Doe",
+  picture: null,
+  org_codes: ["org_01"],
+  organizations: [],
+  user_properties: {},
+};
+
+/**
+ * Builds a minimal KindeContextProps-shaped object for testing.
+ * Only the fields consumed by transformReactAuthStateToNextState are needed.
+ */
+const makeReactAuth = (overrides: {
+  isLoading?: boolean;
+  isAuthenticated?: boolean;
+  accessToken?: string | undefined;
+  idToken?: string | undefined;
+}): KindeContextProps => {
+  const {
+    isLoading = false,
+    isAuthenticated = false,
+    accessToken = undefined,
+    idToken = undefined,
+  } = overrides;
+
+  return {
+    isLoading,
+    isAuthenticated,
+    getAccessToken: async () => accessToken,
+    getIdToken: async () => idToken,
+    // remaining KindeContextProps methods — not used by the transform
+    user: undefined,
+    error: undefined,
+    login: async () => {},
+    logout: async () => {},
+    register: async () => {},
+    getToken: async () => undefined,
+    getClaims: async () => null,
+    getClaim: async () => null,
+    getUserProfile: async () => null,
+    getPermission: async () => ({ isGranted: false, orgCode: null }),
+    getPermissions: async () => ({ permissions: [], orgCode: null }),
+    getRoles: async () => [],
+    getOrganization: async () => null,
+    getCurrentOrganization: async () => null,
+    getUserOrganizations: async () => null,
+    getFlag: async () => null,
+    generatePortalUrl: async () => ({ url: new URL("https://example.com") }),
+    refreshToken: async () => ({ success: false, error: "no-op" }),
+  } as unknown as KindeContextProps;
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("transformReactAuthStateToNextState — isLoading correctness", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Default: jwtDecoder returns null (no tokens decoded)
+    mockJwtDecoder.mockReturnValue(null);
+  });
+
+  // ── Scenario 1: React SDK still loading ──────────────────────────────────
+  it("returns isLoading true when reactAuthState.isLoading is true", async () => {
+    const reactAuth = makeReactAuth({ isLoading: true, isAuthenticated: false });
+
+    const result = await transformReactAuthStateToNextState(reactAuth);
+
+    expect(result.isLoading).toBe(true);
+    expect(result.user).toBeNull();
+    expect(result.isAuthenticated).toBe(false);
+  });
+
+  // ── Scenario 2: THE BUG — isAuthenticated true but tokens not decoded yet ─
+  // React SDK says "done and authenticated" but storage reads returned nothing.
+  // The guard: isLoading || (isAuthenticated && user === null) keeps it true.
+  it("returns isLoading true when isAuthenticated is true but tokens are not yet decoded", async () => {
+    // getAccessToken / getIdToken return undefined (tokens missing from storage)
+    // jwtDecoder returns null (nothing to decode)
+    const reactAuth = makeReactAuth({
+      isLoading: false,
+      isAuthenticated: true,
+      accessToken: undefined,
+      idToken: undefined,
+    });
+
+    const result = await transformReactAuthStateToNextState(reactAuth);
+
+    // Guard fires: isAuthenticated=true but user=null → stay loading
+    expect(result.isLoading).toBe(true);
+    expect(result.user).toBeNull();
+  });
+
+  // ── Scenario 3: Genuinely unauthenticated ────────────────────────────────
+  // React SDK done, not authenticated, no tokens → isLoading false immediately.
+  it("returns isLoading false when not authenticated and no tokens (logged-out state)", async () => {
+    const reactAuth = makeReactAuth({
+      isLoading: false,
+      isAuthenticated: false,
+      accessToken: undefined,
+      idToken: undefined,
+    });
+
+    const result = await transformReactAuthStateToNextState(reactAuth);
+
+    // Guard does NOT fire: isAuthenticated=false → correctly unauthenticated
+    expect(result.isLoading).toBe(false);
+    expect(result.user).toBeNull();
+    expect(result.isAuthenticated).toBe(false);
+  });
+
+  // ── Scenario 4: Fully authenticated and tokens decoded ───────────────────
+  it("returns isLoading false with user when authenticated and tokens decoded", async () => {
+    mockJwtDecoder
+      .mockReturnValueOnce(DECODED_ACCESS_TOKEN) // first call → accessToken
+      .mockReturnValueOnce(DECODED_ID_TOKEN);    // second call → idToken
+
+    const reactAuth = makeReactAuth({
+      isLoading: false,
+      isAuthenticated: true,
+      accessToken: "encoded.access.token",
+      idToken: "encoded.id.token",
+    });
+
+    const result = await transformReactAuthStateToNextState(reactAuth);
+
+    // Guard does NOT fire: isAuthenticated=true and user is populated
+    expect(result.isLoading).toBe(false);
+    expect(result.user).not.toBeNull();
+    expect(result.user?.id).toBe("user_01");
+    expect(result.isAuthenticated).toBe(false); // always false in transform — constructKindeClientState derives it
+  });
+
+  // ── Scenario 5: isLoading true always wins ───────────────────────────────
+  it("returns isLoading true when both isLoading and isAuthenticated are true", async () => {
+    mockJwtDecoder
+      .mockReturnValueOnce(DECODED_ACCESS_TOKEN)
+      .mockReturnValueOnce(DECODED_ID_TOKEN);
+
+    const reactAuth = makeReactAuth({
+      isLoading: true,
+      isAuthenticated: true,
+      accessToken: "encoded.access.token",
+      idToken: "encoded.id.token",
+    });
+
+    const result = await transformReactAuthStateToNextState(reactAuth);
+
+    expect(result.isLoading).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// constructKindeClientState — isAuthenticated derived from !!user
+// ---------------------------------------------------------------------------
+
+describe("constructKindeClientState — isAuthenticated derivation", () => {
+  it("sets isAuthenticated false when user is null", () => {
+    const state = {
+      isLoading: false,
+      isAuthenticated: false,
+      user: null,
+      accessToken: null,
+      accessTokenEncoded: null,
+      idToken: null,
+      idTokenRaw: null,
+      error: null,
+      featureFlags: {},
+      organization: null,
+      permissions: null,
+      userOrganizations: null,
+    };
+
+    const result = constructKindeClientState(state as any);
+    expect(result.isAuthenticated).toBe(false);
+  });
+
+  it("sets isAuthenticated true when user is present", () => {
+    const state = {
+      isLoading: false,
+      isAuthenticated: false, // hardcoded false in transform, overridden here
+      user: { id: "user_01", email: "jane@example.com" },
+      accessToken: null,
+      accessTokenEncoded: null,
+      idToken: null,
+      idTokenRaw: null,
+      error: null,
+      featureFlags: {},
+      organization: null,
+      permissions: null,
+      userOrganizations: null,
+    };
+
+    const result = constructKindeClientState(state as any);
+    expect(result.isAuthenticated).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Provider path vs Providerless path — isLoading sources are independent
+// ---------------------------------------------------------------------------
+
+describe("providerless path — constructKindeClientState receives KindeNextClientState directly", () => {
+  // useProviderlessKindeAuth calls constructKindeClientState(getFetchedState())
+  // where getFetchedState() comes from useSessionSync, not from the React SDK.
+  // This path is NOT affected by the transform fix at all.
+  it("respects isLoading from KindeNextClientState in providerless mode", () => {
+    const loadingState = {
+      isLoading: true,
+      isAuthenticated: false,
+      user: null,
+      accessToken: null,
+      accessTokenEncoded: null,
+      idToken: null,
+      idTokenRaw: null,
+      error: null,
+      featureFlags: {},
+      organization: null,
+      permissions: null,
+      userOrganizations: null,
+    };
+
+    const result = constructKindeClientState(loadingState as any);
+    expect(result.isLoading).toBe(true);
+    expect(result.isAuthenticated).toBe(false);
+  });
+
+  it("resolves correctly when providerless state has user", () => {
+    const resolvedState = {
+      isLoading: false,
+      isAuthenticated: true,
+      user: { id: "user_01", email: "jane@example.com" },
+      accessToken: null,
+      accessTokenEncoded: null,
+      idToken: null,
+      idTokenRaw: null,
+      error: null,
+      featureFlags: {},
+      organization: null,
+      permissions: null,
+      userOrganizations: null,
+    };
+
+    const result = constructKindeClientState(resolvedState as any);
+    expect(result.isLoading).toBe(false);
+    expect(result.isAuthenticated).toBe(true);
+  });
+});

--- a/src/frontend/factories/index.ts
+++ b/src/frontend/factories/index.ts
@@ -81,7 +81,8 @@ export const transformReactAuthStateToNextState = async (
     idTokenRaw: idToken,
     isAuthenticated: false,
     isLoading:
-      reactAuthState.isLoading || (reactAuthState.isAuthenticated && user === null),
+      reactAuthState.isLoading ||
+      (reactAuthState.isAuthenticated && user === null),
     organization: {
       orgCode: organization,
       orgName,

--- a/src/frontend/factories/index.ts
+++ b/src/frontend/factories/index.ts
@@ -68,6 +68,10 @@ export const transformReactAuthStateToNextState = async (
   const orgName = decodedAccessToken?.org_name;
   const orgProperties = decodedAccessToken?.organization_properties;
   const orgNames = decodedIdToken?.organizations ?? [];
+  const user =
+    decodedIdToken && decodedAccessToken
+      ? generateUserObject(decodedIdToken, decodedAccessToken)
+      : null;
   return {
     accessToken: decodedAccessToken,
     accessTokenEncoded: accessToken,
@@ -76,7 +80,8 @@ export const transformReactAuthStateToNextState = async (
     idToken: decodedIdToken,
     idTokenRaw: idToken,
     isAuthenticated: false,
-    isLoading: reactAuthState.isLoading,
+    isLoading:
+      reactAuthState.isLoading || (reactAuthState.isAuthenticated && user === null),
     organization: {
       orgCode: organization,
       orgName,
@@ -99,10 +104,7 @@ export const transformReactAuthStateToNextState = async (
       permissions,
       orgCode: organization,
     },
-    user:
-      decodedIdToken && decodedAccessToken
-        ? generateUserObject(decodedIdToken, decodedAccessToken)
-        : null,
+    user,
     userOrganizations: {
       orgCodes: userOrganizations,
       orgs: orgNames?.map((org) => ({


### PR DESCRIPTION
# Explain your changes

Fixes #431 

`transformReactAuthStateToNextState` was reading `isLoading` directly from the React SDK state while deriving `user` from an independent async token decode. This created a window where the React SDK had already set `isLoading: false` and `isAuthenticated: true` (valid session, tokens in storage) but the decoded `user` was still `null` — for example when a token refresh failed transiently but existing tokens remained in storage. `constructKindeClientState` then derived `isAuthenticated: !!user = false`, so the Next.js SDK briefly advertised a fully resolved unauthenticated state even though the user was authenticated.

The fix extracts `user` before the return statement and guards `isLoading`:

```ts
isLoading: reactAuthState.isLoading || (reactAuthState.isAuthenticated && user === null)
```

If the React SDK confirms the session is authenticated but the token decode has not yet produced a user, `isLoading` stays `true` until the state is consistent. Genuinely unauthenticated users (`isAuthenticated: false`) are unaffected — the guard does not fire and `isLoading` correctly becomes `false`.

Tests added cover:
- React SDK `isLoading: true` propagates through unchanged
- `isAuthenticated: true` with no decoded tokens → guard fires → `isLoading: true`
- `isAuthenticated: false` with no tokens → guard does not fire → `isLoading: false` (logged-out state correct)
- Fully authenticated with decoded tokens → `isLoading: false` with user populated
- Providerless path (`useSessionSync` → `constructKindeClientState` directly) is unaffected and continues to work correctly

# Checklist

- [x] I have read the ["Pull requests" section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
