### PR TITLE
fix: detect Next.js App Router prefetch requests in isPreFetch

### DIFF
--- a/src/utils/isPreFetch.test.ts
+++ b/src/utils/isPreFetch.test.ts
@@ -23,6 +23,13 @@ describe("isPreFetch", () => {
     expect(isPreFetch(headers)).toBe(true);
   });
 
+  it("should return true when next-router-prefetch header is 1", () => {
+    const headers = new Headers({
+      "next-router-prefetch": "1",
+    });
+    expect(isPreFetch(headers)).toBe(true);
+  });
+
   it("should return false when no prefetch headers are present", () => {
     const headers = new Headers({
       "content-type": "application/json",

--- a/src/utils/isPreFetch.ts
+++ b/src/utils/isPreFetch.ts
@@ -1,8 +1,8 @@
 export function isPreFetch(headers: Headers): boolean {
-  const isPrefetch =
+  return (
     headers.get("purpose") === "prefetch" ||
     headers.get("x-purpose") === "prefetch" ||
-    headers.get("x-moz") === "prefetch";
-
-  return !!isPrefetch;
+    headers.get("x-moz") === "prefetch" ||
+    headers.get("next-router-prefetch") === "1"
+  );
 }


### PR DESCRIPTION
# Explain your changes

The `isPreFetch` guard in the auth handlers (`login`, `register`, `logout`, `createOrg`, `portal`) only detected browser-level prefetch headers (`purpose: prefetch`, `x-purpose: prefetch`, `x-moz: prefetch`). It did not detect Next.js App Router's own prefetch header (`next-router-prefetch: 1`), sent when a `<Link>` component pointing to an auth route appears in the viewport.

Without this fix, a `<Link href="/api/auth/login">` in the app would cause Next.js to silently prefetch the login route in the background, triggering the full OAuth flow — generating PKCE state, writing to session — before the user ever clicks the link. This could corrupt in-progress auth flows or silently log users out (if the logout handler was prefetched).

Added `next-router-prefetch: 1` detection to `isPreFetch`:

```ts
headers.get("next-router-prefetch") === "1"
```

**Tested** by simulating the prefetch header directly via curl against a production build of the playground:

```bash
# prefetch — handler fires and skips immediately
curl http://localhost:3000/api/auth/login -H "next-router-prefetch: 1" -H "rsc: 1"

# real navigation — full OAuth flow runs as expected
curl http://localhost:3000/api/auth/login
```

Unit tests updated in `isPreFetch.test.ts` to cover the new header.

> **Note:** The SDK's `LoginLink` component already uses a plain `<a>` tag (not Next.js `<Link>`) as a deliberate safeguard against this. This fix closes the gap for cases where developers use `<Link>` directly or add `<link rel="prefetch">` hints pointing at auth routes.

# Checklist

- [x] I have read the ["Pull requests" section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
