### PR TITLE
fix(KindeProvider): render children on server to restore SSR

### DIFF
--- a/src/frontend/KindeProvider.tsx
+++ b/src/frontend/KindeProvider.tsx
@@ -4,7 +4,7 @@ import {
   ActivityTimeoutConfig,
   TimeoutActivityType,
 } from "@kinde-oss/kinde-auth-react";
-import React, { useMemo } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { useSessionSync } from "./hooks/internal/use-session-sync";
 import * as store from "./store";
 import { storageSettings } from "@kinde-oss/kinde-auth-react/utils";
@@ -21,7 +21,10 @@ export const KindeProvider = ({
   waitForInitialLoad,
   activityTimeout,
 }: KindeProviderProps) => {
+  const [hasMounted, setHasMounted] = useState(false);
   const { loading, config, refreshHandler } = useSessionSync();
+
+  useEffect(() => setHasMounted(true), []);
 
   // Wrap the user's onTimeout callback to handle Next.js logout
   const wrappedActivityTimeout = useMemo(() => {
@@ -58,6 +61,8 @@ export const KindeProvider = ({
   }, [activityTimeout]);
 
   storageSettings.onRefreshHandler = refreshHandler;
+
+  if (!hasMounted) return <>{children}</>;
 
   if (loading && waitForInitialLoad) return null;
   if (!config && !loading) {


### PR DESCRIPTION
# Explain your changes

## Problem

Since v2.10.0, Pages Router apps using `KindeProvider` received a blank
`<div id="__next"></div>` in the initial server-rendered HTML, even when
`getServerSideProps` returned data correctly. The data was present in
`__NEXT_DATA__` but the page body was empty on first load — content only
appeared after client-side JavaScript hydrated.

## Root cause

`KindeProvider` wraps children in `KindeReactProvider` (from
`kinde-auth-react`) with `forceChildrenRender`. Internally,
`KindeReactProvider` gates rendering behind `initStarted`, a `useState`
value that is only set to `true` inside `init()`, which is called from a
`useEffect`. Since `useEffect` never runs on the server, `initStarted`
stays `false` on every SSR pass and `KindeReactProvider` renders an
empty fragment instead of children.

Before v2.10.0, `KindeProvider` was `OldAuthProvider` which rendered
`{children}` unconditionally — SSR worked because there was no
`KindeReactProvider` gate.

## Fix

Add a `hasMounted` guard to `KindeProvider`. Before the component mounts
(server render and first client render), children are returned directly,
bypassing `KindeReactProvider`. After hydration, `useEffect` fires,
`hasMounted` becomes `true`, and `KindeReactProvider` takes over the
client-side auth lifecycle as normal.

This keeps the server/client boundary clean: the server renders content
immediately, and the client re-renders with the full auth provider after
mount with no hydration mismatch.

# Checklist

- [x] I have read the ["Pull requests" section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
