### PR TITLE
fix: add npm license metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "@kinde-oss/kinde-auth-nextjs",
   "version": "2.12.2",
   "description": "Kinde Auth SDK for NextJS",
+  "license": "MIT",
   "main": "dist/cjs/index.js",
   "module": "dist/index.js",
   "typings": "dist/types/src/index.d.ts",


### PR DESCRIPTION
## Summary
- Add npm license metadata to the package manifest.
- Use `MIT`, matching the repository LICENSE.

## Validation
- `node -e "const p=require('./package.json'); if(p.name!=='@kinde-oss/kinde-auth-nextjs') throw new Error('wrong package'); if(p.license!=='MIT') throw new Error('missing MIT license'); console.log(JSON.stringify({name:p.name,version:p.version,license:p.license}))"`
- `git diff --check`
- `npm pack --dry-run --json --ignore-scripts`