### PR TITLE
Fix/correct 401 http status code

### DIFF
--- a/src/authMiddleware/authMiddleware.ts
+++ b/src/authMiddleware/authMiddleware.ts
@@ -19,11 +19,17 @@ import { TWENTY_NINE_DAYS } from "src/utils/constants";
  * Redirects to the register page with the invitation code, or to login on error.
  */
 const handleInvitationCodeRedirect = (
+  req,
   invitationCode: string,
   registerPage: string,
   loginRedirectUrl: string,
   redirectURLBase: string | undefined,
 ): NextResponse => {
+  const method = req.method?.toUpperCase() ?? "GET";
+  if (method !== "GET" && method !== "HEAD") {
+    return NextResponse.json({ statusCode: 401, message: "Unauthorized" }, { status: 401 });
+  }
+
   try {
     const params = new URLSearchParams();
     params.set("invitation_code", invitationCode);
@@ -95,6 +101,7 @@ const handleMiddleware = async (req, options, onSuccess) => {
 
   if (hasInvitationCode) {
     return handleInvitationCodeRedirect(
+      req,
       invitationCode,
       registerPage,
       loginRedirectUrl,

--- a/src/authMiddleware/authMiddleware.ts
+++ b/src/authMiddleware/authMiddleware.ts
@@ -27,7 +27,10 @@ const handleInvitationCodeRedirect = (
 ): NextResponse => {
   const method = req.method?.toUpperCase() ?? "GET";
   if (method !== "GET" && method !== "HEAD") {
-    return NextResponse.json({ statusCode: 401, message: "Unauthorized" }, { status: 401 });
+    return NextResponse.json(
+      { statusCode: 401, message: "Unauthorized" },
+      { status: 401 },
+    );
   }
 
   try {

--- a/src/frontend/utils.ts
+++ b/src/frontend/utils.ts
@@ -60,6 +60,9 @@ export const fetchKindeState = async (): Promise<FetchKindeStateResponse> => {
   const { message, error, env, ...kindeData } = parsedBody;
 
   if (!res.ok) {
+    if (message === "NOT_LOGGED_IN") {
+      return { success: false, error: "Not logged in", env: env ?? null };
+    }
     return {
       success: false,
       error: error || message || "Failed to fetch Kinde state",
@@ -70,8 +73,6 @@ export const fetchKindeState = async (): Promise<FetchKindeStateResponse> => {
   switch (message) {
     case "OK":
       return { success: true, kindeState: kindeData, env };
-    case "NOT_LOGGED_IN":
-      return { success: false, error: "Not logged in", env };
     default:
       return {
         success: false,

--- a/src/handlers/setup.ts
+++ b/src/handlers/setup.ts
@@ -31,7 +31,7 @@ export const setup = async (routerClient: RouterClient) => {
             redirectUrl: config.redirectURL,
           },
         },
-        { status: 200 },
+        { status: 401 },
       );
     }
 
@@ -59,7 +59,7 @@ export const setup = async (routerClient: RouterClient) => {
               redirectUrl: config.redirectURL,
             },
           },
-          { status: 500 },
+          { status: 401 },
         );
       }
     }
@@ -85,7 +85,7 @@ export const setup = async (routerClient: RouterClient) => {
             redirectUrl: config.redirectURL,
           },
         },
-        { status: 500 },
+        { status: 401 },
       );
     }
 
@@ -105,7 +105,7 @@ export const setup = async (routerClient: RouterClient) => {
             redirectUrl: config.redirectURL,
           },
         },
-        { status: 500 },
+        { status: 401 },
       );
     }
 
@@ -120,7 +120,7 @@ export const setup = async (routerClient: RouterClient) => {
             redirectUrl: config.redirectURL,
           },
         },
-        { status: 500 },
+        { status: 401 },
       );
     }
 

--- a/tests/authMiddleware/authMiddleware.test.ts
+++ b/tests/authMiddleware/authMiddleware.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// --------------------------------------------------------------------------
+// Mocks
+// vi.mock is hoisted above imports, so factory functions cannot reference
+// variables declared in this file — use vi.fn() directly inside factories.
+// --------------------------------------------------------------------------
+
+vi.mock("next/server", () => ({
+  NextResponse: {
+    json: vi.fn(),
+    redirect: vi.fn(),
+    next: vi.fn(() => ({
+      cookies: { set: vi.fn(), getAll: vi.fn(() => []) },
+      headers: new Headers(),
+    })),
+  },
+}));
+
+vi.mock("../../src/config/index", () => ({
+  config: {
+    apiPath: "/api/auth",
+    redirectURL: "http://localhost:3000",
+    isDebugMode: false,
+  },
+  routes: {
+    login: "login",
+    register: "register",
+    setup: "setup",
+  },
+}));
+
+vi.mock("../../src/utils/getAccessToken", () => ({
+  getAccessToken: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock("../../src/utils/getIdToken", () => ({
+  getIdToken: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock("../../src/session/kindeServerClient", () => ({
+  kindeClient: { refreshTokens: vi.fn() },
+}));
+
+vi.mock("../../src/session/sessionManager", () => ({
+  sessionManager: vi.fn().mockResolvedValue({}),
+}));
+
+vi.mock("../../src/utils/jwt/validation", () => ({
+  isTokenExpired: vi.fn().mockReturnValue(false),
+}));
+
+vi.mock("@kinde/jwt-decoder", () => ({
+  jwtDecoder: vi.fn().mockReturnValue(null),
+}));
+
+vi.mock("../../src/utils/cookies/getSplitSerializedCookies", () => ({
+  getSplitCookies: vi.fn().mockReturnValue([]),
+}));
+
+vi.mock("../../src/utils/copyCookiesToRequest", () => ({
+  copyCookiesToRequest: vi.fn(),
+}));
+
+vi.mock("../../src/utils/cookies/getStandardCookieOptions", () => ({
+  getStandardCookieOptions: vi.fn().mockReturnValue({}),
+}));
+
+vi.mock("../../src/utils/isPublicPathMatch", () => ({
+  isPublicPathMatch: vi.fn().mockReturnValue(false),
+}));
+
+import { NextResponse } from "next/server";
+import { withAuth } from "../../src/authMiddleware/authMiddleware";
+
+// --------------------------------------------------------------------------
+// Helpers
+// --------------------------------------------------------------------------
+
+const makeRequest = (method: string, url: string): Request => {
+  const req = new Request(url, { method });
+  (req as any).nextUrl = new URL(url);
+  (req as any).cookies = {
+    get: vi.fn().mockReturnValue(null),
+    getAll: vi.fn(() => []),
+  };
+  return req;
+};
+
+// --------------------------------------------------------------------------
+// Tests
+// --------------------------------------------------------------------------
+
+describe("authMiddleware — non-GET/HEAD returns HTTP 401", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("handleInvitationCodeRedirect", () => {
+    it("returns HTTP 401 for POST with invitation_code", async () => {
+      const req = makeRequest(
+        "POST",
+        "http://localhost:3000/dashboard?invitation_code=abc123",
+      );
+      await withAuth(req);
+      expect(NextResponse.json).toHaveBeenCalledWith(
+        { statusCode: 401, message: "Unauthorized" },
+        { status: 401 },
+      );
+    });
+
+    it("returns HTTP 401 for PUT with invitation_code", async () => {
+      const req = makeRequest(
+        "PUT",
+        "http://localhost:3000/dashboard?invitation_code=abc123",
+      );
+      await withAuth(req);
+      expect(NextResponse.json).toHaveBeenCalledWith(
+        { statusCode: 401, message: "Unauthorized" },
+        { status: 401 },
+      );
+    });
+
+    it("redirects GET with invitation_code instead of returning 401", async () => {
+      const req = makeRequest(
+        "GET",
+        "http://localhost:3000/dashboard?invitation_code=abc123",
+      );
+      await withAuth(req);
+      expect(NextResponse.json).not.toHaveBeenCalled();
+      expect(NextResponse.redirect).toHaveBeenCalled();
+    });
+
+    it("redirects HEAD with invitation_code instead of returning 401", async () => {
+      const req = makeRequest(
+        "HEAD",
+        "http://localhost:3000/dashboard?invitation_code=abc123",
+      );
+      await withAuth(req);
+      expect(NextResponse.json).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("loginRedirect", () => {
+    it("redirects GET to login when unauthenticated", async () => {
+      const req = makeRequest("GET", "http://localhost:3000/dashboard");
+      await withAuth(req);
+      expect(NextResponse.json).not.toHaveBeenCalled();
+      expect(NextResponse.redirect).toHaveBeenCalled();
+    });
+  });
+});

--- a/tests/frontend/fetchKindeState.test.ts
+++ b/tests/frontend/fetchKindeState.test.ts
@@ -72,7 +72,11 @@ describe("fetchKindeState — auth failure HTTP status handling", () => {
 
   it("returns { success: false } with error message for HTTP 401 ACCESS_TOKEN_DECODE_FAILED", async () => {
     mockFetch(
-      { message: "ACCESS_TOKEN_DECODE_FAILED", error: "Invalid token", env: ENV },
+      {
+        message: "ACCESS_TOKEN_DECODE_FAILED",
+        error: "Invalid token",
+        env: ENV,
+      },
       401,
     );
 

--- a/tests/frontend/fetchKindeState.test.ts
+++ b/tests/frontend/fetchKindeState.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// --------------------------------------------------------------------------
+// Mocks
+// --------------------------------------------------------------------------
+
+vi.mock("../../src/config/index.js", () => ({
+  config: {
+    apiPath: "/api/auth",
+    isDebugMode: false,
+  },
+  routes: {
+    setup: "setup",
+  },
+}));
+
+import { fetchKindeState } from "../../src/frontend/utils";
+
+// --------------------------------------------------------------------------
+// Helpers
+// --------------------------------------------------------------------------
+
+const ENV = {
+  clientId: "client_123",
+  issuerUrl: "https://example.kinde.com",
+  redirectUrl: "http://localhost:3000",
+};
+
+const mockFetch = (body: object, status: number) => {
+  global.fetch = vi.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    json: vi.fn().mockResolvedValue(body),
+  } as any);
+};
+
+// --------------------------------------------------------------------------
+// Tests
+// --------------------------------------------------------------------------
+
+describe("fetchKindeState — auth failure HTTP status handling", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns { success: false, error: 'Not logged in' } for HTTP 401 NOT_LOGGED_IN", async () => {
+    mockFetch({ message: "NOT_LOGGED_IN", env: ENV }, 401);
+
+    const result = await fetchKindeState();
+
+    expect(result).toMatchObject({ success: false, error: "Not logged in" });
+  });
+
+  it("passes env through for NOT_LOGGED_IN", async () => {
+    mockFetch({ message: "NOT_LOGGED_IN", env: ENV }, 401);
+
+    const result = await fetchKindeState();
+
+    expect(result).toMatchObject({ success: false, env: ENV });
+  });
+
+  it("returns { success: false } with error message for HTTP 401 REFRESH_FAILED", async () => {
+    mockFetch(
+      { message: "REFRESH_FAILED", error: "Token expired", env: ENV },
+      401,
+    );
+
+    const result = await fetchKindeState();
+
+    expect(result).toMatchObject({ success: false, error: "Token expired" });
+  });
+
+  it("returns { success: false } with error message for HTTP 401 ACCESS_TOKEN_DECODE_FAILED", async () => {
+    mockFetch(
+      { message: "ACCESS_TOKEN_DECODE_FAILED", error: "Invalid token", env: ENV },
+      401,
+    );
+
+    const result = await fetchKindeState();
+
+    expect(result).toMatchObject({ success: false, error: "Invalid token" });
+  });
+
+  it("returns { success: false } with error message for HTTP 401 ID_TOKEN_DECODE_FAILED", async () => {
+    mockFetch(
+      { message: "ID_TOKEN_DECODE_FAILED", error: "Invalid token", env: ENV },
+      401,
+    );
+
+    const result = await fetchKindeState();
+
+    expect(result).toMatchObject({ success: false, error: "Invalid token" });
+  });
+
+  it("returns { success: false } with error message for HTTP 401 TOKENS_MISSING", async () => {
+    mockFetch(
+      { message: "TOKENS_MISSING", error: "No access or id token", env: ENV },
+      401,
+    );
+
+    const result = await fetchKindeState();
+
+    expect(result).toMatchObject({
+      success: false,
+      error: "No access or id token",
+    });
+  });
+
+  it("falls back to message when no error field is present on non-ok response", async () => {
+    mockFetch({ message: "UNKNOWN_FAILURE", env: ENV }, 401);
+
+    const result = await fetchKindeState();
+
+    expect(result).toMatchObject({
+      success: false,
+      error: "UNKNOWN_FAILURE",
+    });
+  });
+
+  it("returns { success: true } for HTTP 200 OK", async () => {
+    mockFetch(
+      {
+        message: "OK",
+        accessToken: {},
+        idToken: {},
+        user: { id: "user_01" },
+        permissions: { permissions: [], orgCode: "org_01" },
+        organization: { orgCode: "org_01" },
+        featureFlags: {},
+        userOrganizations: { orgCodes: [] },
+        env: ENV,
+      },
+      200,
+    );
+
+    const result = await fetchKindeState();
+
+    expect(result.success).toBe(true);
+  });
+
+  it("returns { success: false } when fetch throws a network error", async () => {
+    global.fetch = vi.fn().mockRejectedValue(new Error("network error"));
+
+    const result = await fetchKindeState();
+
+    expect(result).toMatchObject({
+      success: false,
+      error: "Failed to fetch Kinde state",
+    });
+  });
+});

--- a/tests/handlers/setup.test.ts
+++ b/tests/handlers/setup.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// --------------------------------------------------------------------------
+// Mocks
+// --------------------------------------------------------------------------
+
+vi.mock("../../src/utils/getAccessToken", () => ({
+  getAccessToken: vi.fn(),
+}));
+
+vi.mock("../../src/utils/getIdToken", () => ({
+  getIdToken: vi.fn(),
+}));
+
+vi.mock("../../src/config/index", () => ({
+  config: {
+    clientID: "client_123",
+    issuerURL: "https://example.kinde.com",
+    redirectURL: "http://localhost:3000",
+    isDebugMode: false,
+  },
+}));
+
+vi.mock("../../src/session/sessionManager", () => ({
+  sessionManager: vi.fn().mockResolvedValue({}),
+}));
+
+vi.mock("../../src/session/kindeServerClient", () => ({
+  kindeClient: { refreshTokens: vi.fn() },
+}));
+
+vi.mock("../../src/utils/jwt/validation", () => ({
+  isTokenExpired: vi.fn().mockReturnValue(false),
+}));
+
+vi.mock("@kinde/jwt-decoder", () => ({
+  jwtDecoder: vi.fn(),
+}));
+
+vi.mock("../../src/utils/generateUserObject", () => ({
+  generateUserObject: vi.fn().mockReturnValue({ id: "user_01" }),
+}));
+
+import { setup } from "../../src/handlers/setup";
+import { getAccessToken } from "../../src/utils/getAccessToken";
+import { getIdToken } from "../../src/utils/getIdToken";
+import { isTokenExpired } from "../../src/utils/jwt/validation";
+import { jwtDecoder } from "@kinde/jwt-decoder";
+import { kindeClient } from "../../src/session/kindeServerClient";
+
+const mockGetAccessToken = vi.mocked(getAccessToken);
+const mockGetIdToken = vi.mocked(getIdToken);
+const mockIsTokenExpired = vi.mocked(isTokenExpired);
+const mockJwtDecoder = vi.mocked(jwtDecoder);
+const mockKindeClient = vi.mocked(kindeClient);
+
+// --------------------------------------------------------------------------
+// Helpers
+// --------------------------------------------------------------------------
+
+const ENV = {
+  clientId: "client_123",
+  issuerUrl: "https://example.kinde.com",
+  redirectUrl: "http://localhost:3000",
+};
+
+const makeRouterClient = () => {
+  const json = vi.fn();
+  return { req: {}, res: {}, json };
+};
+
+// --------------------------------------------------------------------------
+// Tests
+// --------------------------------------------------------------------------
+
+describe("setup handler — auth failure HTTP status codes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns HTTP 401 for NOT_LOGGED_IN when no tokens present", async () => {
+    mockGetAccessToken.mockResolvedValue(null);
+    mockGetIdToken.mockResolvedValue(null);
+
+    const routerClient = makeRouterClient();
+    await setup(routerClient as any);
+
+    expect(routerClient.json).toHaveBeenCalledWith(
+      { message: "NOT_LOGGED_IN", env: ENV },
+      { status: 401 },
+    );
+  });
+
+  it("returns HTTP 401 for REFRESH_FAILED when token refresh throws", async () => {
+    mockGetAccessToken.mockResolvedValue("access_token");
+    mockGetIdToken.mockResolvedValue("id_token");
+    mockIsTokenExpired.mockReturnValue(true);
+    (mockKindeClient.refreshTokens as any).mockRejectedValue(
+      new Error("refresh failed"),
+    );
+
+    const routerClient = makeRouterClient();
+    await setup(routerClient as any);
+
+    expect(routerClient.json).toHaveBeenCalledWith(
+      expect.objectContaining({ message: "REFRESH_FAILED" }),
+      { status: 401 },
+    );
+  });
+
+  it("returns HTTP 401 for ACCESS_TOKEN_DECODE_FAILED when access token decode throws", async () => {
+    mockGetAccessToken.mockResolvedValue("bad_access_token");
+    mockGetIdToken.mockResolvedValue("id_token");
+    mockIsTokenExpired.mockReturnValue(false);
+    mockJwtDecoder.mockImplementationOnce(() => {
+      throw new Error("decode error");
+    });
+
+    const routerClient = makeRouterClient();
+    await setup(routerClient as any);
+
+    expect(routerClient.json).toHaveBeenCalledWith(
+      expect.objectContaining({ message: "ACCESS_TOKEN_DECODE_FAILED" }),
+      { status: 401 },
+    );
+  });
+
+  it("returns HTTP 401 for ID_TOKEN_DECODE_FAILED when id token decode throws", async () => {
+    mockGetAccessToken.mockResolvedValue("access_token");
+    mockGetIdToken.mockResolvedValue("bad_id_token");
+    mockIsTokenExpired.mockReturnValue(false);
+    mockJwtDecoder
+      .mockReturnValueOnce({ permissions: [], org_code: "org_01" })
+      .mockImplementationOnce(() => {
+        throw new Error("decode error");
+      });
+
+    const routerClient = makeRouterClient();
+    await setup(routerClient as any);
+
+    expect(routerClient.json).toHaveBeenCalledWith(
+      expect.objectContaining({ message: "ID_TOKEN_DECODE_FAILED" }),
+      { status: 401 },
+    );
+  });
+
+  it("returns HTTP 401 for TOKENS_MISSING when jwtDecoder returns null", async () => {
+    mockGetAccessToken.mockResolvedValue("access_token");
+    mockGetIdToken.mockResolvedValue("id_token");
+    mockIsTokenExpired.mockReturnValue(false);
+    mockJwtDecoder.mockReturnValue(null);
+
+    const routerClient = makeRouterClient();
+    await setup(routerClient as any);
+
+    expect(routerClient.json).toHaveBeenCalledWith(
+      expect.objectContaining({ message: "TOKENS_MISSING" }),
+      { status: 401 },
+    );
+  });
+
+  it("returns HTTP 500 for unexpected errors in the outer try/catch", async () => {
+    mockGetAccessToken.mockRejectedValue(new Error("unexpected"));
+
+    const routerClient = makeRouterClient();
+    await setup(routerClient as any);
+
+    expect(routerClient.json).toHaveBeenCalledWith(
+      expect.objectContaining({ message: "SETUP_FAILED" }),
+      { status: 500 },
+    );
+  });
+});


### PR DESCRIPTION
# Explain your changes

Previously, several auth failure responses were returning incorrect HTTP status codes — `200` or `500` — even when the body indicated an authentication failure. This caused clients to misinterpret responses as successful or as server errors.

Changes made:
- `handleInvitationCodeRedirect` in `authMiddleware.ts`: non-GET/HEAD requests now return HTTP `401` (was implicit `200`), and `req` is passed as a parameter to support the method check.
- `setup.ts`: the following responses now return HTTP `401`:
  - `NOT_LOGGED_IN` (was `200`)
  - `REFRESH_FAILED` (was `500`)
  - `ACCESS_TOKEN_DECODE_FAILED` (was `500`)
  - `ID_TOKEN_DECODE_FAILED` (was `500`)
  - `TOKENS_MISSING` (was `500`)
- `fetchKindeState` in `frontend/utils.ts`: updated to handle `NOT_LOGGED_IN` within the `!res.ok` path, preserving the same `{ success: false, error: "Not logged in" }` return value as before.

Tests added:
- `tests/authMiddleware/authMiddleware.test.ts`: verifies POST/PUT with `invitation_code` return HTTP `401`, and GET/HEAD still redirect normally.
- `tests/handlers/setup.test.ts`: verifies each auth failure path returns HTTP `401`, and that unexpected errors still return `500`.
- `tests/frontend/fetchKindeState.test.ts`: verifies all `401` error paths return `success: false` with the correct error message, including that `NOT_LOGGED_IN` continues to return `"Not logged in"` as before.

# Checklist

- [x] I have read the ["Pull requests" section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
