### PR TITLE
fix: return 204 for auth route prefetch instead of null

### DIFF
--- a/src/handlers/createOrg.ts
+++ b/src/handlers/createOrg.ts
@@ -10,7 +10,7 @@ import { isPreFetch } from "../utils/isPreFetch";
 export const createOrg = async (routerClient: RouterClient) => {
   const headers = await getHeaders(routerClient.req);
   if (isPreFetch(headers)) {
-    return null;
+    return routerClient.noContent();
   }
 
   const org_name = routerClient.getSearchParam("org_name");

--- a/src/handlers/login.ts
+++ b/src/handlers/login.ts
@@ -11,7 +11,7 @@ import { config } from "../config/index";
 export const login = async (routerClient: RouterClient) => {
   const headers = await getHeaders(routerClient.req);
   if (isPreFetch(headers)) {
-    return null;
+    return routerClient.noContent();
   }
 
   const passedState = routerClient.searchParams.get("state");

--- a/src/handlers/logout.ts
+++ b/src/handlers/logout.ts
@@ -10,7 +10,7 @@ import { getHeaders } from "../utils/getHeaders";
 export const logout = async (routerClient: RouterClient) => {
   const headers = await getHeaders(routerClient.req);
   if (isPreFetch(headers)) {
-    return null;
+    return routerClient.noContent();
   }
 
   const authUrl = await routerClient.kindeClient.logout(

--- a/src/handlers/portal.ts
+++ b/src/handlers/portal.ts
@@ -18,7 +18,7 @@ import { config, routes } from "../config";
 export const portal = async (routerClient: RouterClient) => {
   const headers = await getHeaders(routerClient.req);
   if (isPreFetch(headers)) {
-    return null;
+    return routerClient.noContent();
   }
 
   const storage = new MemoryStorage();

--- a/src/handlers/register.ts
+++ b/src/handlers/register.ts
@@ -11,7 +11,7 @@ import { config } from "../config/index";
 export const register = async (routerClient: RouterClient) => {
   const headers = await getHeaders(routerClient.req);
   if (isPreFetch(headers)) {
-    return null;
+    return routerClient.noContent();
   }
 
   const authUrl = await routerClient.kindeClient.register(

--- a/src/routerClients/AppRouterClient.js
+++ b/src/routerClients/AppRouterClient.js
@@ -73,6 +73,13 @@ export default class AppRouterClient extends RouterClient {
     return NextResponse.json(data, status);
   }
 
+  noContent() {
+    return new NextResponse(null, {
+      status: 204,
+      headers: { "Cache-Control": "no-store" },
+    });
+  }
+
   error() {
     return Response.error;
   }

--- a/src/routerClients/PagesRouterClient.js
+++ b/src/routerClients/PagesRouterClient.js
@@ -68,6 +68,11 @@ export default class PagesRouterClient extends RouterClient {
     return this.res.status(status.status).json(data);
   }
 
+  noContent() {
+    this.res.setHeader("Cache-Control", "no-store");
+    return this.res.status(204).end();
+  }
+
   /**
    *
    * @param {string} key

--- a/src/routerClients/RouterClient.js
+++ b/src/routerClients/RouterClient.js
@@ -41,6 +41,16 @@ export default class RouterClient {
     throw new Error("Method 'json()' must be implemented.");
   }
 
+  /**
+   * Empty response for prefetch requests. Must be a real Response on App Router
+   * (null triggers a 500) and must not include a body that the browser can reuse
+   * as a navigation document.
+   * @returns
+   */
+  noContent() {
+    throw new Error("Method 'noContent()' must be implemented.");
+  }
+
   error() {
     throw new Error("Method 'error()' must be implemented.");
   }

--- a/tests/handlers/login.prefetch.test.ts
+++ b/tests/handlers/login.prefetch.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../../src/utils/getHeaders", () => ({
+  getHeaders: vi.fn(),
+}));
+
+vi.mock("../../src/utils/isPreFetch", () => ({
+  isPreFetch: vi.fn(),
+}));
+
+vi.mock("../../src/config/index", () => ({
+  config: {
+    postLoginRedirectURL: undefined,
+  },
+}));
+
+import { login } from "../../src/handlers/login";
+import { getHeaders } from "../../src/utils/getHeaders";
+import { isPreFetch } from "../../src/utils/isPreFetch";
+
+const mockGetHeaders = vi.mocked(getHeaders);
+const mockIsPreFetch = vi.mocked(isPreFetch);
+
+describe("login handler — prefetch requests", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns noContent Response instead of null for prefetch requests", async () => {
+    const prefetchResponse = new Response(null, {
+      status: 204,
+      headers: { "Cache-Control": "no-store" },
+    });
+    const noContent = vi.fn().mockReturnValue(prefetchResponse);
+    const routerClient = {
+      req: {},
+      noContent,
+      searchParams: new URLSearchParams(),
+      getSearchParam: vi.fn(),
+      sessionManager: { setSessionItem: vi.fn() },
+      kindeClient: { login: vi.fn() },
+      redirect: vi.fn(),
+    };
+
+    mockGetHeaders.mockResolvedValue(new Headers());
+    mockIsPreFetch.mockReturnValue(true);
+
+    const result = await login(routerClient as never);
+
+    expect(noContent).toHaveBeenCalledOnce();
+    expect(result).toBe(prefetchResponse);
+    expect(result).toBeInstanceOf(Response);
+    expect(result!.status).toBe(204);
+    expect(result!.headers.get("Cache-Control")).toBe("no-store");
+    expect(routerClient.kindeClient.login).not.toHaveBeenCalled();
+  });
+});

--- a/tests/routerClients/AppRouterClient.noContent.test.ts
+++ b/tests/routerClients/AppRouterClient.noContent.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("next/headers", () => ({
+  cookies: vi.fn(),
+}));
+
+vi.mock("next/server", () => {
+  class NextResponse extends Response {
+    static json(data: unknown, init?: ResponseInit) {
+      return new NextResponse(JSON.stringify(data), {
+        ...init,
+        headers: {
+          "content-type": "application/json",
+          ...(init?.headers || {}),
+        },
+      });
+    }
+    static redirect(url: string | URL) {
+      return new NextResponse(null, {
+        status: 307,
+        headers: { Location: String(url) },
+      });
+    }
+  }
+  return { NextResponse };
+});
+
+vi.mock("../../src/config/index", () => ({
+  config: {
+    clientOptions: {
+      authDomain: "https://example.kinde.com",
+      clientId: "client_123",
+      clientSecret: "secret",
+      redirectURL: "http://localhost:3000/api/auth/kinde_callback",
+      logoutRedirectURL: "http://localhost:3000",
+    },
+    grantType: "authorization_code",
+    redirectURL: "http://localhost:3000",
+    apiPath: "/api/auth",
+  },
+}));
+
+vi.mock("@kinde-oss/kinde-typescript-sdk", () => ({
+  createKindeServerClient: vi.fn(() => ({})),
+}));
+
+vi.mock("../../src/session/sessionManager", () => ({
+  appRouterSessionManager: vi.fn(),
+}));
+
+import AppRouterClient from "../../src/routerClients/AppRouterClient";
+
+describe("AppRouterClient.noContent", () => {
+  it("returns a 204 Response with Cache-Control: no-store", () => {
+    const req = {
+      url: "http://localhost:3000/api/auth/login",
+      nextUrl: new URL("http://localhost:3000/api/auth/login"),
+    };
+
+    const client = new AppRouterClient(req, {}, {});
+    const response = client.noContent();
+
+    expect(response).toBeInstanceOf(Response);
+    expect(response.status).toBe(204);
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+  });
+});


### PR DESCRIPTION
App Router rejects null from route handlers with a 500. Prefetch detection in 2.13.0 made that path common; return an empty no-store 204 so OAuth is still skipped without an invalid response.

# Explain your changes

Fixes #553

In v2.13.0, `#528` extended `isPreFetch` to detect Next.js App Router’s `next-router-prefetch: 1` header. That correctly stops prefeches of auth routes from starting OAuth / mutating session state.

Those handlers still early-returned `null` on prefetch. App Router requires a real `Response`, so this became a 500:

`No response is returned from route handler … Expected a Response object but received 'null'`

That path was rare before (only browser `purpose` / `x-purpose` / `x-moz` headers). After `#528`, it fires whenever middleware redirects a Link prefetch to `/api/auth/login` (or register / logout / etc.).

History: `#343` returned `200` + JSON `"Prefetch skipped"`, then `#354` reverted to `null` because browsers reused that body as the navigation document.

This change adds `RouterClient.noContent()`:
- App Router: `204` with `Cache-Control: no-store` (valid Response, empty body)
- Pages Router: `res.status(204).end()` with the same cache header

Wired into `login`, `register`, `logout`, `createOrg`, and `portal`. Prefetch still skips OAuth; it no longer returns an invalid handler result.

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._