### PR TITLE
fix: ensure multi-tab sessions properly handle logged_out state and support 401 errors

### DIFF
--- a/docs/upgrade-middleware-401-cross-tab.md
+++ b/docs/upgrade-middleware-401-cross-tab.md
@@ -1,0 +1,173 @@
+# Upgrade guide: middleware 401s and cross-tab logout
+
+This guide is for apps on **`@kinde-oss/kinde-auth-nextjs` 2.11.x** (or earlier) that use `withAuth` middleware and are seeing redirects or 5xx responses after logout in another tab.
+
+**Target version:** latest (`v2.13.0` or newer, including builds that ship cross-tab logout sync).
+
+---
+
+## Do you need to change your middleware file?
+
+**Usually no.** The `withAuth` API and options (`publicPaths`, `isReturnToCurrentPage`, `loginPage`, `isAuthorized`, `orgCode`, etc.) are unchanged.
+
+A typical setup keeps working as-is:
+
+```ts
+// middleware.ts
+import { withAuth } from "@kinde-oss/kinde-auth-nextjs/middleware";
+
+export default withAuth(async function middleware(req) {
+  // your logic
+}, {
+  publicPaths: ["/", "/about"],
+});
+
+export const config = {
+  matcher: ["/((?!_next/static|_next/image|favicon.ico).*)"],
+};
+```
+
+You do **not** need to:
+
+- Change import paths
+- Add new middleware options for 401s or cross-tab sync
+- Rewrite matchers solely for this upgrade
+
+---
+
+## What changes automatically after you upgrade
+
+### 1. Unauthenticated API calls return `401` instead of redirect / 5xx
+
+| Request type | Before (e.g. 2.11.0) | After (latest) |
+|---|---|---|
+| Document navigation (GET/HEAD, HTML) | Redirect to login | Redirect to login (unchanged) |
+| Mutating methods (POST, PUT, PATCH, DELETE, …) | Redirect to login | **`401` JSON** `{ statusCode: 401, message: "Unauthorized" }` |
+| Fetch/XHR-style GET (JSON `Accept`, `Sec-Fetch-Mode: cors`, `Sec-Fetch-Dest: empty`) | Redirect to login | **`401` JSON** |
+| `/api/auth/setup` auth failures | Often **200** / **500** | **`401`** |
+
+No middleware config is required for this; it is built into `withAuth`.
+
+### 2. Cross-tab logout UI sync (client)
+
+If you use `KindeProvider` and `LogoutLink`:
+
+- Logging out in Tab A notifies other tabs
+- Other tabs clear in-memory client auth state
+- Focusing a stale tab revalidates via `/setup` and clears state if cookies are gone
+
+No middleware changes are required for this either.
+
+---
+
+## Recommended upgrade steps
+
+### Step 1 — Bump the package
+
+```bash
+pnpm add @kinde-oss/kinde-auth-nextjs@latest
+# or: npm / yarn equivalent
+```
+
+Redeploy so Edge/Node middleware runs the new SDK build.
+
+### Step 2 — Confirm middleware covers the routes that need auth
+
+`withAuth` only runs where your `matcher` (and `publicPaths`) allow it.
+
+- Protected **pages and APIs** should be included in the matcher.
+- Use `publicPaths` for routes that must stay public (middleware can still refresh tokens on those paths when configured that way).
+- Prefer running middleware broadly and marking public routes explicitly, rather than omitting APIs from the matcher.
+
+Example:
+
+```ts
+export default withAuth(req, {
+  publicPaths: ["/", "/pricing", "/api/health"],
+});
+
+export const config = {
+  matcher: ["/((?!_next/static|_next/image|favicon.ico).*)"],
+};
+```
+
+### Step 3 — Update client API error handling (important)
+
+After upgrade, unauthenticated `fetch` / XHR calls should receive **`401`**, not an HTML login redirect.
+
+Ensure client code:
+
+1. Checks `response.status === 401` (and does **not** assume a redirect to login).
+2. Treats `401` as logged out (clear UI state, prompt login, or call your logout flow).
+3. Does not parse redirect HTML as JSON.
+
+Example:
+
+```ts
+const res = await fetch("/api/orders");
+if (res.status === 401) {
+  // session gone (e.g. logged out in another tab)
+  // update UI / redirect to login yourself if desired
+  return;
+}
+const data = await res.json();
+```
+
+If you previously followed redirects and treated “ended up on login” as the signal, switch to explicit `401` handling.
+
+### Step 4 — Prefer SDK logout UI for cross-tab sync
+
+Use `LogoutLink` (or ensure logout goes through the SDK logout route) so other tabs get the `logged_out` broadcast:
+
+```tsx
+import { LogoutLink } from "@kinde-oss/kinde-auth-nextjs/components";
+
+<LogoutLink>Sign out</LogoutLink>
+```
+
+If users hit `/api/auth/logout` via a plain `<a href>` without `LogoutLink`, cookies still clear, but other tabs may only update when they regain focus (visibility revalidation).
+
+Wrap the app in `KindeProvider` if you rely on client auth state (`useKindeBrowserClient`).
+
+### Step 5 — Smoke-test the reported scenario
+
+1. Open two tabs on a protected page while logged in.
+2. Log out in Tab A.
+3. Switch to Tab B — UI should show logged out (immediately via broadcast, or on focus).
+4. From Tab B, call a protected API — expect **`401`**, not a login redirect body or 5xx.
+5. Navigate a protected page in the browser — expect redirect to login (document navigation).
+
+---
+
+## When you *might* need middleware code changes
+
+Only if you customized auth failure behavior yourself:
+
+| Situation | Action |
+|---|---|
+| Custom middleware that **reimplements** redirects instead of using `withAuth`’s response | Prefer composing with `withAuth`, or mirror the new 401 rules for API requests |
+| App assumed **all** unauthenticated hits are redirects (including POST/fetch) | Update those callers for `401` (Step 3) |
+| GET “API” routes that send `Accept: text/html` and navigate-style fetch headers | May still redirect; send JSON/`cors`/`empty` fetch headers, or handle redirect explicitly |
+| Routes not in the middleware matcher | Add them, or protect with `protectApi` / server session checks |
+
+There is **no new required option** on `withAuth` for this upgrade.
+
+---
+
+## Optional: protecting Route Handlers without middleware
+
+If some APIs are outside the matcher, use server helpers / `protectApi` as you do today. Unauthenticated responses should remain **`401`**, consistent with middleware API behavior on latest.
+
+---
+
+## Summary
+
+| Area | Required action |
+|---|---|
+| `middleware.ts` `withAuth` setup | **None** for standard setups |
+| Package version | Upgrade to latest |
+| Client `fetch` / API callers | Handle **`401`** as logged out |
+| `KindeProvider` + `LogoutLink` | Recommended for cross-tab UI sync |
+| Matcher / `publicPaths` | Review only if APIs were excluded from middleware |
+
+**Bottom line:** existing middleware configuration can stay; the upgrade mainly changes **response behavior** (401 for API-style requests) and adds **client cross-tab sync**. Update callers that expected redirects or 5xx after logout.

--- a/docs/upgrade-middleware-401-cross-tab.md
+++ b/docs/upgrade-middleware-401-cross-tab.md
@@ -16,11 +16,14 @@ A typical setup keeps working as-is:
 // middleware.ts
 import { withAuth } from "@kinde-oss/kinde-auth-nextjs/middleware";
 
-export default withAuth(async function middleware(req) {
-  // your logic
-}, {
-  publicPaths: ["/", "/about"],
-});
+export default withAuth(
+  async function middleware(req) {
+    // your logic
+  },
+  {
+    publicPaths: ["/", "/about"],
+  },
+);
 
 export const config = {
   matcher: ["/((?!_next/static|_next/image|favicon.ico).*)"],
@@ -39,12 +42,12 @@ You do **not** need to:
 
 ### 1. Unauthenticated API calls return `401` instead of redirect / 5xx
 
-| Request type | Before (e.g. 2.11.0) | After (latest) |
-|---|---|---|
-| Document navigation (GET/HEAD, HTML) | Redirect to login | Redirect to login (unchanged) |
-| Mutating methods (POST, PUT, PATCH, DELETE, …) | Redirect to login | **`401` JSON** `{ statusCode: 401, message: "Unauthorized" }` |
-| Fetch/XHR-style GET (JSON `Accept`, `Sec-Fetch-Mode: cors`, `Sec-Fetch-Dest: empty`) | Redirect to login | **`401` JSON** |
-| `/api/auth/setup` auth failures | Often **200** / **500** | **`401`** |
+| Request type                                                                         | Before (e.g. 2.11.0)    | After (latest)                                                |
+| ------------------------------------------------------------------------------------ | ----------------------- | ------------------------------------------------------------- |
+| Document navigation (GET/HEAD, HTML)                                                 | Redirect to login       | Redirect to login (unchanged)                                 |
+| Mutating methods (POST, PUT, PATCH, DELETE, …)                                       | Redirect to login       | **`401` JSON** `{ statusCode: 401, message: "Unauthorized" }` |
+| Fetch/XHR-style GET (JSON `Accept`, `Sec-Fetch-Mode: cors`, `Sec-Fetch-Dest: empty`) | Redirect to login       | **`401` JSON**                                                |
+| `/api/auth/setup` auth failures                                                      | Often **200** / **500** | **`401`**                                                     |
 
 No middleware config is required for this; it is built into `withAuth`.
 
@@ -122,7 +125,7 @@ Use `LogoutLink` (or ensure logout goes through the SDK logout route) so other t
 ```tsx
 import { LogoutLink } from "@kinde-oss/kinde-auth-nextjs/components";
 
-<LogoutLink>Sign out</LogoutLink>
+<LogoutLink>Sign out</LogoutLink>;
 ```
 
 If users hit `/api/auth/logout` via a plain `<a href>` without `LogoutLink`, cookies still clear, but other tabs may only update when they regain focus (visibility revalidation).
@@ -139,16 +142,16 @@ Wrap the app in `KindeProvider` if you rely on client auth state (`useKindeBrows
 
 ---
 
-## When you *might* need middleware code changes
+## When you _might_ need middleware code changes
 
 Only if you customized auth failure behavior yourself:
 
-| Situation | Action |
-|---|---|
-| Custom middleware that **reimplements** redirects instead of using `withAuth`’s response | Prefer composing with `withAuth`, or mirror the new 401 rules for API requests |
-| App assumed **all** unauthenticated hits are redirects (including POST/fetch) | Update those callers for `401` (Step 3) |
-| GET “API” routes that send `Accept: text/html` and navigate-style fetch headers | May still redirect; send JSON/`cors`/`empty` fetch headers, or handle redirect explicitly |
-| Routes not in the middleware matcher | Add them, or protect with `protectApi` / server session checks |
+| Situation                                                                                | Action                                                                                    |
+| ---------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| Custom middleware that **reimplements** redirects instead of using `withAuth`’s response | Prefer composing with `withAuth`, or mirror the new 401 rules for API requests            |
+| App assumed **all** unauthenticated hits are redirects (including POST/fetch)            | Update those callers for `401` (Step 3)                                                   |
+| GET “API” routes that send `Accept: text/html` and navigate-style fetch headers          | May still redirect; send JSON/`cors`/`empty` fetch headers, or handle redirect explicitly |
+| Routes not in the middleware matcher                                                     | Add them, or protect with `protectApi` / server session checks                            |
 
 There is **no new required option** on `withAuth` for this upgrade.
 
@@ -162,12 +165,12 @@ If some APIs are outside the matcher, use server helpers / `protectApi` as you d
 
 ## Summary
 
-| Area | Required action |
-|---|---|
-| `middleware.ts` `withAuth` setup | **None** for standard setups |
-| Package version | Upgrade to latest |
-| Client `fetch` / API callers | Handle **`401`** as logged out |
-| `KindeProvider` + `LogoutLink` | Recommended for cross-tab UI sync |
-| Matcher / `publicPaths` | Review only if APIs were excluded from middleware |
+| Area                             | Required action                                   |
+| -------------------------------- | ------------------------------------------------- |
+| `middleware.ts` `withAuth` setup | **None** for standard setups                      |
+| Package version                  | Upgrade to latest                                 |
+| Client `fetch` / API callers     | Handle **`401`** as logged out                    |
+| `KindeProvider` + `LogoutLink`   | Recommended for cross-tab UI sync                 |
+| Matcher / `publicPaths`          | Review only if APIs were excluded from middleware |
 
 **Bottom line:** existing middleware configuration can stay; the upgrade mainly changes **response behavior** (401 for API-style requests) and adds **client cross-tab sync**. Update callers that expected redirects or 5xx after logout.

--- a/src/authMiddleware/authMiddleware.ts
+++ b/src/authMiddleware/authMiddleware.ts
@@ -12,7 +12,7 @@ import { OAuth2CodeExchangeResponse } from "@kinde-oss/kinde-typescript-sdk";
 import { copyCookiesToRequest } from "../utils/copyCookiesToRequest";
 import { getStandardCookieOptions } from "../utils/cookies/getStandardCookieOptions";
 import { isPublicPathMatch } from "../utils/isPublicPathMatch";
-import { isNonSafeMethod } from "../utils/isNonSafeMethod";
+import { shouldReturnUnauthorizedJson } from "../utils/shouldReturnUnauthorizedJson";
 import { buildAuthRedirectUrl } from "../utils/buildAuthRedirectUrl";
 
 /**
@@ -20,8 +20,8 @@ import { buildAuthRedirectUrl } from "../utils/buildAuthRedirectUrl";
  * Redirects to the register page with the invitation code, or falls back to
  * the auth redirect URL on error.
  *
- * Non-safe HTTP methods (POST, PUT, etc.) cannot follow a 3xx redirect, so
- * a 401 JSON response is returned instead.
+ * API/XHR-style requests cannot usefully follow a login redirect, so a 401
+ * JSON response is returned instead.
  */
 const handleInvitationCodeRedirect = (
   req,
@@ -30,7 +30,7 @@ const handleInvitationCodeRedirect = (
   authRedirectUrl: string,
   redirectURLBase: string | undefined,
 ): NextResponse => {
-  if (isNonSafeMethod(req)) {
+  if (shouldReturnUnauthorizedJson(req)) {
     return NextResponse.json(
       { statusCode: 401, message: "Unauthorized" },
       { status: 401 },
@@ -65,14 +65,14 @@ const handleInvitationCodeRedirect = (
 
 /**
  * Redirects the user to the auth/login page, or returns a 401 JSON response
- * for non-safe HTTP methods (POST, PUT, etc.) that cannot follow a 3xx redirect.
+ * for API/XHR-style requests (non-safe methods, CORS fetch, JSON Accept).
  */
 const authRedirect = (
   req,
   authRedirectUrl: string,
   redirectURLBase: string | undefined,
 ): NextResponse => {
-  if (isNonSafeMethod(req)) {
+  if (shouldReturnUnauthorizedJson(req)) {
     return NextResponse.json(
       { statusCode: 401, message: "Unauthorized" },
       { status: 401 },

--- a/src/authMiddleware/authMiddleware.ts
+++ b/src/authMiddleware/authMiddleware.ts
@@ -66,6 +66,7 @@ const handleInvitationCodeRedirect = (
 /**
  * Redirects the user to the auth/login page, or returns a 401 JSON response
  * for API/XHR-style requests (non-safe methods, CORS fetch, JSON Accept).
+ * Next.js App Router RSC navigations still redirect.
  */
 const authRedirect = (
   req,

--- a/src/components/LogoutLink.jsx
+++ b/src/components/LogoutLink.jsx
@@ -1,4 +1,7 @@
 import { config, routes } from "../config/index";
+import React from "react";
+import { publishSessionEvent } from "../frontend/sessionChannel";
+
 /**
  * @typedef {Object} PropsType
  * @prop {React.ReactNode} children
@@ -10,15 +13,27 @@ import { config, routes } from "../config/index";
 /**
  * @param {Props} props
  */
-export function LogoutLink({ children, postLogoutRedirectURL, ...props }) {
+export function LogoutLink({
+  children,
+  postLogoutRedirectURL,
+  onClick,
+  ...props
+}) {
+  const href = `${config.apiPath}/${routes.logout}${
+    postLogoutRedirectURL
+      ? `?post_logout_redirect_url=${postLogoutRedirectURL}`
+      : ""
+  }`;
+
   return (
     <a
-      href={`${config.apiPath}/${routes.logout}${
-        postLogoutRedirectURL
-          ? `?post_logout_redirect_url=${postLogoutRedirectURL}`
-          : ""
-      }`}
+      href={href}
       {...props}
+      onClick={(event) => {
+        // Notify other tabs before navigation clears this tab's cookies.
+        publishSessionEvent({ type: "logged_out" });
+        onClick?.(event);
+      }}
     >
       {children}
     </a>

--- a/src/components/LogoutLink.jsx
+++ b/src/components/LogoutLink.jsx
@@ -1,5 +1,4 @@
 import { config, routes } from "../config/index";
-import React from "react";
 import { publishSessionEvent } from "../frontend/sessionChannel";
 
 /**

--- a/src/components/LogoutLink.jsx
+++ b/src/components/LogoutLink.jsx
@@ -29,7 +29,9 @@ export function LogoutLink({
       href={href}
       {...props}
       onClick={(event) => {
-        // Notify other tabs before navigation clears this tab's cookies.
+        // This tab navigates to /logout, so we cannot wait for cookies to clear.
+        // Other tabs ignore cookie-based revalidation until /setup reports
+        // logged out (see useSessionSync).
         publishSessionEvent({ type: "logged_out" });
         onClick?.(event);
       }}

--- a/src/frontend/KindeProvider.tsx
+++ b/src/frontend/KindeProvider.tsx
@@ -9,6 +9,7 @@ import { useSessionSync } from "./hooks/internal/use-session-sync";
 import * as store from "./store";
 import { storageSettings } from "@kinde-oss/kinde-auth-react/utils";
 import { config as sdkConfig } from "../config/index";
+import { publishSessionEvent } from "./sessionChannel";
 
 type KindeProviderProps = {
   children: React.ReactNode;
@@ -46,6 +47,7 @@ export const KindeProvider = ({
         if (type === TimeoutActivityType.timeout) {
           try {
             await fetch(`${sdkConfig.apiPath}/end_session`);
+            publishSessionEvent({ type: "logged_out" });
             await refreshHandler();
           } catch (error) {
             if (sdkConfig.isDebugMode) {
@@ -55,7 +57,7 @@ export const KindeProvider = ({
         }
       },
     };
-  }, [activityTimeout]);
+  }, [activityTimeout, refreshHandler]);
 
   storageSettings.onRefreshHandler = refreshHandler;
 

--- a/src/frontend/KindeProvider.tsx
+++ b/src/frontend/KindeProvider.tsx
@@ -46,8 +46,10 @@ export const KindeProvider = ({
         // End session by revoking tokens and clearing local session
         if (type === TimeoutActivityType.timeout) {
           try {
-            await fetch(`${sdkConfig.apiPath}/end_session`);
-            publishSessionEvent({ type: "logged_out" });
+            const res = await fetch(`${sdkConfig.apiPath}/end_session`);
+            if (res.ok) {
+              publishSessionEvent({ type: "logged_out" });
+            }
             await refreshHandler();
           } catch (error) {
             if (sdkConfig.isDebugMode) {

--- a/src/frontend/hooks/internal/use-session-sync.ts
+++ b/src/frontend/hooks/internal/use-session-sync.ts
@@ -10,6 +10,7 @@ import { fetchKindeState } from "../../utils";
 import { DefaultKindeNextClientState } from "../../constants";
 import * as store from "../../store";
 import {
+  clearRefreshTimer,
   getDecodedToken,
   RefreshTokenResult,
   setRefreshTimer,
@@ -17,6 +18,7 @@ import {
 } from "@kinde-oss/kinde-auth-react/utils";
 import { JWTDecoded } from "@kinde/jwt-decoder";
 import { config as sdkConfig } from "../../../config/index";
+import { subscribeSessionEvents } from "../../sessionChannel";
 
 export const calculateExpirySeconds = async (): Promise<number | null> => {
   const token = await getDecodedToken<JWTDecoded>("accessToken");
@@ -32,8 +34,12 @@ export const useSessionSync = (shouldAutoRefresh = true) => {
     DefaultKindeNextClientState,
   );
 
-  const handleError = useCallback(
-    async (error: string) => {
+  const isRevalidatingRef = useRef(false);
+  const hasCompletedInitialLoadRef = useRef(false);
+
+  const clearClientSession = useCallback(
+    async (error: string | null = null) => {
+      clearRefreshTimer();
       await store.clientStorage.destroySession();
       setFetchedState({
         ...DefaultKindeNextClientState,
@@ -42,6 +48,13 @@ export const useSessionSync = (shouldAutoRefresh = true) => {
       });
     },
     [setFetchedState],
+  );
+
+  const handleError = useCallback(
+    async (error: string) => {
+      await clearClientSession(error);
+    },
+    [clearClientSession],
   );
 
   const refreshHandlerRef = useRef<(() => Promise<RefreshTokenResult>) | null>(
@@ -60,7 +73,7 @@ export const useSessionSync = (shouldAutoRefresh = true) => {
       if (shouldAutoRefresh) {
         const expiry = await calculateExpirySeconds();
         const handler = refreshHandlerRef.current;
-        if (handler && expiry !== null) {
+        if (handler && expiry !== null && expiry > 0) {
           setRefreshTimer(expiry, handler);
         }
       }
@@ -108,6 +121,7 @@ export const useSessionSync = (shouldAutoRefresh = true) => {
       await handleError(setupResponse.error);
       setConfig(setupResponse.env);
       setLoading(false);
+      hasCompletedInitialLoadRef.current = true;
 
       return {
         success: false,
@@ -118,6 +132,7 @@ export const useSessionSync = (shouldAutoRefresh = true) => {
     await updateTokensAndSetRefresh(setupResponse.kindeState);
     setConfig(setupResponse.env);
     setLoading(false);
+    hasCompletedInitialLoadRef.current = true;
 
     return {
       success: true,
@@ -130,6 +145,39 @@ export const useSessionSync = (shouldAutoRefresh = true) => {
     setupState();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  // Cross-tab logout: clear in-memory client state when another tab logs out.
+  useEffect(() => {
+    return subscribeSessionEvents(async (event) => {
+      if (event.type !== "logged_out") return;
+      if (sdkConfig.isDebugMode) {
+        console.log("useSessionSync: received logged_out from another tab");
+      }
+      await clearClientSession(null);
+    });
+  }, [clearClientSession]);
+
+  // Revalidate session when the tab becomes visible again (covers logout via
+  // raw /api/auth/logout URL without LogoutLink, and expired cookies).
+  useEffect(() => {
+    const onVisibilityChange = async () => {
+      if (document.visibilityState !== "visible") return;
+      if (!hasCompletedInitialLoadRef.current) return;
+      if (isRevalidatingRef.current) return;
+
+      isRevalidatingRef.current = true;
+      try {
+        await setupState();
+      } finally {
+        isRevalidatingRef.current = false;
+      }
+    };
+
+    document.addEventListener("visibilitychange", onVisibilityChange);
+    return () => {
+      document.removeEventListener("visibilitychange", onVisibilityChange);
+    };
+  }, [setupState]);
 
   return {
     config,

--- a/src/frontend/hooks/internal/use-session-sync.ts
+++ b/src/frontend/hooks/internal/use-session-sync.ts
@@ -167,6 +167,20 @@ export const useSessionSync = (shouldAutoRefresh = true) => {
     }
 
     await updateTokensAndSetRefresh(setupResponse.kindeState);
+
+    // Another tab logged out while tokens were being written — do not keep
+    // the stale authenticated state that updateTokensAndSetRefresh just applied.
+    if (epoch !== sessionEpochRef.current) {
+      await clearClientSession(null);
+      setLoading(false);
+      hasCompletedInitialLoadRef.current = true;
+
+      return {
+        success: false,
+        error: "Session invalidated",
+      };
+    }
+
     setConfig(setupResponse.env);
     setLoading(false);
     hasCompletedInitialLoadRef.current = true;
@@ -176,7 +190,7 @@ export const useSessionSync = (shouldAutoRefresh = true) => {
       [StorageKeys.accessToken]: setupResponse.kindeState.accessTokenEncoded,
       [StorageKeys.idToken]: setupResponse.kindeState.idTokenRaw,
     };
-  }, [handleError, updateTokensAndSetRefresh]);
+  }, [clearClientSession, handleError, updateTokensAndSetRefresh]);
 
   useEffect(() => {
     setupState();

--- a/src/frontend/hooks/internal/use-session-sync.ts
+++ b/src/frontend/hooks/internal/use-session-sync.ts
@@ -38,6 +38,16 @@ export const useSessionSync = (shouldAutoRefresh = true) => {
   const hasCompletedInitialLoadRef = useRef(false);
   // Bumped on cross-tab logout so in-flight setupState results are discarded.
   const sessionEpochRef = useRef(0);
+  // `logged_out` is published before /logout has necessarily cleared cookies.
+  // Ignore authenticated /setup results until we observe a definite logged-out
+  // response — otherwise focus revalidation can restore the session we just cleared.
+  const ignoreAuthenticatedSetupRef = useRef(false);
+
+  const confirmLogoutIfUnauthenticated = (error: string | undefined) => {
+    if (error === "Not logged in") {
+      ignoreAuthenticatedSetupRef.current = false;
+    }
+  };
 
   const clearClientSession = useCallback(
     async (error: string | null = null) => {
@@ -93,7 +103,8 @@ export const useSessionSync = (shouldAutoRefresh = true) => {
     const epoch = sessionEpochRef.current;
     const setupResponse = await fetchKindeState();
 
-    if (!setupResponse.success) {
+    if (setupResponse.success === false) {
+      confirmLogoutIfUnauthenticated(setupResponse.error);
       await handleError("User is unauthenticated or refresh failed");
       return {
         success: false,
@@ -104,6 +115,14 @@ export const useSessionSync = (shouldAutoRefresh = true) => {
     // Another tab logged out (or session was otherwise invalidated) while this
     // request was in flight — do not restore stale authenticated state.
     if (epoch !== sessionEpochRef.current) {
+      await clearClientSession(null);
+      return {
+        success: false,
+        error: "Session invalidated",
+      };
+    }
+
+    if (ignoreAuthenticatedSetupRef.current) {
       await clearClientSession(null);
       return {
         success: false,
@@ -155,6 +174,7 @@ export const useSessionSync = (shouldAutoRefresh = true) => {
       if (sdkConfig.isDebugMode) {
         console.log("setupResponse unsuccessful", setupResponse);
       }
+      confirmLogoutIfUnauthenticated(setupResponse.error);
       await handleError(setupResponse.error);
       setConfig(setupResponse.env);
       setLoading(false);
@@ -163,6 +183,19 @@ export const useSessionSync = (shouldAutoRefresh = true) => {
       return {
         success: false,
         error: setupResponse.error,
+      };
+    }
+
+    if (ignoreAuthenticatedSetupRef.current) {
+      if (setupResponse.env) {
+        setConfig(setupResponse.env);
+      }
+      setLoading(false);
+      hasCompletedInitialLoadRef.current = true;
+
+      return {
+        success: false,
+        error: "Session invalidated",
       };
     }
 
@@ -205,12 +238,15 @@ export const useSessionSync = (shouldAutoRefresh = true) => {
         console.log("useSessionSync: received logged_out from another tab");
       }
       sessionEpochRef.current += 1;
+      ignoreAuthenticatedSetupRef.current = true;
       await clearClientSession(null);
     });
   }, [clearClientSession]);
 
   // Revalidate session when the tab becomes visible again (covers logout via
   // raw /api/auth/logout URL without LogoutLink, and expired cookies).
+  // After a BroadcastChannel logged_out, setupState will not restore a session
+  // from still-valid cookies until /setup reports logged out.
   useEffect(() => {
     const onVisibilityChange = async () => {
       if (document.visibilityState !== "visible") return;

--- a/src/frontend/hooks/internal/use-session-sync.ts
+++ b/src/frontend/hooks/internal/use-session-sync.ts
@@ -90,6 +90,7 @@ export const useSessionSync = (shouldAutoRefresh = true) => {
   );
 
   const refreshHandler = useCallback(async (): Promise<RefreshTokenResult> => {
+    const epoch = sessionEpochRef.current;
     const setupResponse = await fetchKindeState();
 
     if (!setupResponse.success) {
@@ -100,14 +101,32 @@ export const useSessionSync = (shouldAutoRefresh = true) => {
       };
     }
 
+    // Another tab logged out (or session was otherwise invalidated) while this
+    // request was in flight — do not restore stale authenticated state.
+    if (epoch !== sessionEpochRef.current) {
+      await clearClientSession(null);
+      return {
+        success: false,
+        error: "Session invalidated",
+      };
+    }
+
     await updateTokensAndSetRefresh(setupResponse.kindeState);
+
+    if (epoch !== sessionEpochRef.current) {
+      await clearClientSession(null);
+      return {
+        success: false,
+        error: "Session invalidated",
+      };
+    }
 
     return {
       success: true,
       idToken: setupResponse.kindeState.idTokenRaw,
       accessToken: setupResponse.kindeState.accessTokenEncoded,
     };
-  }, [handleError, updateTokensAndSetRefresh]);
+  }, [clearClientSession, handleError, updateTokensAndSetRefresh]);
 
   useEffect(() => {
     refreshHandlerRef.current = refreshHandler;
@@ -120,6 +139,12 @@ export const useSessionSync = (shouldAutoRefresh = true) => {
     // Another tab logged out (or session was otherwise invalidated) while this
     // request was in flight — do not restore stale authenticated state.
     if (epoch !== sessionEpochRef.current) {
+      if (setupResponse.env) {
+        setConfig(setupResponse.env);
+      }
+      setLoading(false);
+      hasCompletedInitialLoadRef.current = true;
+
       return {
         success: false,
         error: "Session invalidated",

--- a/src/frontend/hooks/internal/use-session-sync.ts
+++ b/src/frontend/hooks/internal/use-session-sync.ts
@@ -36,6 +36,8 @@ export const useSessionSync = (shouldAutoRefresh = true) => {
 
   const isRevalidatingRef = useRef(false);
   const hasCompletedInitialLoadRef = useRef(false);
+  // Bumped on cross-tab logout so in-flight setupState results are discarded.
+  const sessionEpochRef = useRef(0);
 
   const clearClientSession = useCallback(
     async (error: string | null = null) => {
@@ -112,7 +114,17 @@ export const useSessionSync = (shouldAutoRefresh = true) => {
   }, [refreshHandler]);
 
   const setupState = useCallback(async () => {
+    const epoch = sessionEpochRef.current;
     const setupResponse = await fetchKindeState();
+
+    // Another tab logged out (or session was otherwise invalidated) while this
+    // request was in flight — do not restore stale authenticated state.
+    if (epoch !== sessionEpochRef.current) {
+      return {
+        success: false,
+        error: "Session invalidated",
+      };
+    }
 
     if (setupResponse.success === false) {
       if (sdkConfig.isDebugMode) {
@@ -153,6 +165,7 @@ export const useSessionSync = (shouldAutoRefresh = true) => {
       if (sdkConfig.isDebugMode) {
         console.log("useSessionSync: received logged_out from another tab");
       }
+      sessionEpochRef.current += 1;
       await clearClientSession(null);
     });
   }, [clearClientSession]);

--- a/src/frontend/sessionChannel.ts
+++ b/src/frontend/sessionChannel.ts
@@ -1,0 +1,102 @@
+export const KINDE_AUTH_CHANNEL_NAME = "kinde-auth";
+export const KINDE_AUTH_STORAGE_KEY = "kinde-auth:event";
+
+export type KindeAuthSessionEvent = {
+  type: "logged_out";
+};
+
+const isBrowser = () => typeof window !== "undefined";
+
+const canUseBroadcastChannel = () => {
+  try {
+    return isBrowser() && typeof BroadcastChannel !== "undefined";
+  } catch {
+    return false;
+  }
+};
+
+/**
+ * Publishes a cross-tab session event so other tabs can clear stale client
+ * auth state after logout (cookies are shared; MemoryStorage is not).
+ */
+export const publishSessionEvent = (event: KindeAuthSessionEvent): void => {
+  if (!isBrowser()) return;
+
+  if (canUseBroadcastChannel()) {
+    try {
+      const channel = new BroadcastChannel(KINDE_AUTH_CHANNEL_NAME);
+      channel.postMessage(event);
+      channel.close();
+      return;
+    } catch {
+      // Fall through to localStorage.
+    }
+  }
+
+  try {
+    localStorage.setItem(
+      KINDE_AUTH_STORAGE_KEY,
+      JSON.stringify({ ...event, ts: Date.now() }),
+    );
+  } catch {
+    // private mode / storage quota — ignore
+  }
+};
+
+/**
+ * Subscribes to cross-tab session events via BroadcastChannel, with a
+ * localStorage fallback for browsers without BroadcastChannel.
+ */
+export const subscribeSessionEvents = (
+  handler: (event: KindeAuthSessionEvent) => void,
+): (() => void) => {
+  if (!isBrowser()) {
+    return () => undefined;
+  }
+
+  let channel: BroadcastChannel | null = null;
+
+  const onMessage = (data: unknown) => {
+    if (
+      data &&
+      typeof data === "object" &&
+      "type" in data &&
+      (data as KindeAuthSessionEvent).type === "logged_out"
+    ) {
+      handler(data as KindeAuthSessionEvent);
+    }
+  };
+
+  if (canUseBroadcastChannel()) {
+    try {
+      channel = new BroadcastChannel(KINDE_AUTH_CHANNEL_NAME);
+      channel.onmessage = (messageEvent) => onMessage(messageEvent.data);
+      return () => {
+        try {
+          channel?.close();
+        } catch {
+          // ignore
+        }
+      };
+    } catch {
+      channel = null;
+    }
+  }
+
+  const onStorage = (storageEvent: StorageEvent) => {
+    if (storageEvent.key !== KINDE_AUTH_STORAGE_KEY || !storageEvent.newValue) {
+      return;
+    }
+    try {
+      onMessage(JSON.parse(storageEvent.newValue));
+    } catch {
+      // ignore malformed payloads
+    }
+  };
+
+  window.addEventListener("storage", onStorage);
+
+  return () => {
+    window.removeEventListener("storage", onStorage);
+  };
+};

--- a/src/utils/shouldReturnUnauthorizedJson.test.ts
+++ b/src/utils/shouldReturnUnauthorizedJson.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "vitest";
+import { shouldReturnUnauthorizedJson } from "./shouldReturnUnauthorizedJson";
+
+const withHeaders = (method: string, headers: Record<string, string> = {}) => ({
+  method,
+  headers: {
+    get: (name: string) => headers[name.toLowerCase()] ?? null,
+  },
+});
+
+describe("shouldReturnUnauthorizedJson", () => {
+  it("returns true for non-safe methods", () => {
+    expect(shouldReturnUnauthorizedJson(withHeaders("POST"))).toBe(true);
+    expect(shouldReturnUnauthorizedJson(withHeaders("DELETE"))).toBe(true);
+  });
+
+  it("returns false for plain GET document navigations", () => {
+    expect(
+      shouldReturnUnauthorizedJson(
+        withHeaders("GET", {
+          accept: "text/html,application/xhtml+xml",
+          "sec-fetch-dest": "document",
+          "sec-fetch-mode": "navigate",
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it("returns true for GET with Sec-Fetch-Dest empty", () => {
+    expect(
+      shouldReturnUnauthorizedJson(
+        withHeaders("GET", { "sec-fetch-dest": "empty" }),
+      ),
+    ).toBe(true);
+  });
+
+  it("returns true for GET with Sec-Fetch-Mode cors", () => {
+    expect(
+      shouldReturnUnauthorizedJson(
+        withHeaders("GET", { "sec-fetch-mode": "cors" }),
+      ),
+    ).toBe(true);
+  });
+
+  it("returns true when Accept prefers application/json", () => {
+    expect(
+      shouldReturnUnauthorizedJson(
+        withHeaders("GET", {
+          accept: "application/json, text/plain, */*",
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("returns false when Accept prefers text/html over json", () => {
+    expect(
+      shouldReturnUnauthorizedJson(
+        withHeaders("GET", {
+          accept: "text/html,application/json",
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it("returns false for GET with no API indicators", () => {
+    expect(shouldReturnUnauthorizedJson(withHeaders("GET"))).toBe(false);
+  });
+});

--- a/src/utils/shouldReturnUnauthorizedJson.test.ts
+++ b/src/utils/shouldReturnUnauthorizedJson.test.ts
@@ -26,6 +26,19 @@ describe("shouldReturnUnauthorizedJson", () => {
     ).toBe(false);
   });
 
+  it("returns false for Next.js App Router RSC / router GET fetches", () => {
+    expect(
+      shouldReturnUnauthorizedJson(
+        withHeaders("GET", {
+          rsc: "1",
+          "next-router-state-tree": "[]",
+          "sec-fetch-dest": "empty",
+          "sec-fetch-mode": "cors",
+        }),
+      ),
+    ).toBe(false);
+  });
+
   it("returns true for GET with Sec-Fetch-Dest empty", () => {
     expect(
       shouldReturnUnauthorizedJson(
@@ -63,6 +76,8 @@ describe("shouldReturnUnauthorizedJson", () => {
   });
 
   it("returns false for GET with no API indicators", () => {
+    // Older Safari omits Sec-Fetch-Dest/Mode; default fetch() often omits Accept.
+    // That combo cannot be distinguished from a document GET, so we redirect.
     expect(shouldReturnUnauthorizedJson(withHeaders("GET"))).toBe(false);
   });
 });

--- a/src/utils/shouldReturnUnauthorizedJson.ts
+++ b/src/utils/shouldReturnUnauthorizedJson.ts
@@ -1,0 +1,52 @@
+import { isNonSafeMethod } from "./isNonSafeMethod";
+
+type HeaderReadable = {
+  method?: string;
+  headers?: {
+    get?: (name: string) => string | null;
+  };
+};
+
+/**
+ * True when `Accept` lists `application/json` before (or without) `text/html`,
+ * which is typical of fetch/XHR API clients rather than document navigations.
+ */
+const prefersJsonOverHtml = (accept: string | null | undefined): boolean => {
+  if (!accept) return false;
+  const normalized = accept.toLowerCase();
+  const jsonIndex = normalized.indexOf("application/json");
+  if (jsonIndex === -1) return false;
+  const htmlIndex = normalized.indexOf("text/html");
+  if (htmlIndex === -1) return true;
+  return jsonIndex < htmlIndex;
+};
+
+/**
+ * Returns true when an unauthenticated request should receive a 401 JSON
+ * response instead of a login redirect.
+ *
+ * Covers non-safe methods (POST, PUT, …) and fetch/XHR-style GETs that prefer
+ * JSON or use CORS/`Sec-Fetch-Dest: empty`. Document navigations still redirect.
+ */
+export const shouldReturnUnauthorizedJson = (req: HeaderReadable): boolean => {
+  if (isNonSafeMethod(req)) {
+    return true;
+  }
+
+  const headers = req.headers;
+  if (!headers?.get) {
+    return false;
+  }
+
+  const secFetchDest = headers.get("sec-fetch-dest")?.toLowerCase();
+  if (secFetchDest === "empty") {
+    return true;
+  }
+
+  const secFetchMode = headers.get("sec-fetch-mode")?.toLowerCase();
+  if (secFetchMode === "cors") {
+    return true;
+  }
+
+  return prefersJsonOverHtml(headers.get("accept"));
+};

--- a/src/utils/shouldReturnUnauthorizedJson.ts
+++ b/src/utils/shouldReturnUnauthorizedJson.ts
@@ -26,7 +26,9 @@ const prefersJsonOverHtml = (accept: string | null | undefined): boolean => {
  * `Sec-Fetch-Dest: empty`, `Sec-Fetch-Mode: cors`), not document navigations.
  * Those must keep the login redirect rather than a JSON 401.
  */
-const isNextAppRouterFetch = (headers: NonNullable<HeaderReadable["headers"]>): boolean => {
+const isNextAppRouterFetch = (
+  headers: NonNullable<HeaderReadable["headers"]>,
+): boolean => {
   if (headers.get("rsc")) {
     return true;
   }

--- a/src/utils/shouldReturnUnauthorizedJson.ts
+++ b/src/utils/shouldReturnUnauthorizedJson.ts
@@ -22,11 +22,27 @@ const prefersJsonOverHtml = (accept: string | null | undefined): boolean => {
 };
 
 /**
+ * Next.js App Router `<Link>` / `router.push` are GET fetches (`RSC: 1`,
+ * `Sec-Fetch-Dest: empty`, `Sec-Fetch-Mode: cors`), not document navigations.
+ * Those must keep the login redirect rather than a JSON 401.
+ */
+const isNextAppRouterFetch = (headers: NonNullable<HeaderReadable["headers"]>): boolean => {
+  if (headers.get("rsc")) {
+    return true;
+  }
+  return Boolean(headers.get("next-router-state-tree"));
+};
+
+/**
  * Returns true when an unauthenticated request should receive a 401 JSON
  * response instead of a login redirect.
  *
  * Covers non-safe methods (POST, PUT, …) and fetch/XHR-style GETs that prefer
- * JSON or use CORS/`Sec-Fetch-Dest: empty`. Document navigations still redirect.
+ * JSON or use CORS/`Sec-Fetch-Dest: empty`. Document navigations and Next.js
+ * App Router RSC / router fetches still redirect.
+ *
+ * Older browsers (notably Safari) omit Sec-Fetch-* and most fetch() calls send
+ * no Accept, so those GETs fall through to a login redirect instead of 401 JSON.
  */
 export const shouldReturnUnauthorizedJson = (req: HeaderReadable): boolean => {
   if (isNonSafeMethod(req)) {
@@ -35,6 +51,10 @@ export const shouldReturnUnauthorizedJson = (req: HeaderReadable): boolean => {
 
   const headers = req.headers;
   if (!headers?.get) {
+    return false;
+  }
+
+  if (isNextAppRouterFetch(headers)) {
     return false;
   }
 
@@ -48,5 +68,6 @@ export const shouldReturnUnauthorizedJson = (req: HeaderReadable): boolean => {
     return true;
   }
 
+  // Last signal: Accept. Missing Sec-Fetch-* + no Accept → redirect (legacy).
   return prefersJsonOverHtml(headers.get("accept"));
 };

--- a/tests/authMiddleware/authMiddleware.test.ts
+++ b/tests/authMiddleware/authMiddleware.test.ts
@@ -77,13 +77,32 @@ import { withAuth } from "../../src/authMiddleware/authMiddleware";
 // Helpers
 // --------------------------------------------------------------------------
 
-const makeRequest = (method: string, url: string): Request => {
+const makeRequest = (
+  method: string,
+  url: string,
+  headers: Record<string, string> = {},
+): Request => {
   const req = new Request(url, { method });
   (req as any).nextUrl = new URL(url);
   (req as any).cookies = {
     get: vi.fn().mockReturnValue(null),
     getAll: vi.fn(() => []),
   };
+
+  // Sec-Fetch-* are forbidden request headers and cannot be set via Request.
+  // Override headers.get so middleware can still read the values under test.
+  const normalized = Object.fromEntries(
+    Object.entries(headers).map(([key, value]) => [key.toLowerCase(), value]),
+  );
+  const originalGet = req.headers.get.bind(req.headers);
+  req.headers.get = (name: string) => {
+    const key = name.toLowerCase();
+    if (Object.prototype.hasOwnProperty.call(normalized, key)) {
+      return normalized[key];
+    }
+    return originalGet(name);
+  };
+
   return req;
 };
 
@@ -172,6 +191,50 @@ describe("authMiddleware — non-GET/HEAD returns HTTP 401", () => {
 
     it("redirects GET to login when unauthenticated", async () => {
       const req = makeRequest("GET", "http://localhost:3000/dashboard");
+      await withAuth(req);
+      expect(NextResponse.json).not.toHaveBeenCalled();
+      expect(NextResponse.redirect).toHaveBeenCalled();
+    });
+
+    it("returns HTTP 401 for GET fetch with Sec-Fetch-Dest empty", async () => {
+      const req = makeRequest("GET", "http://localhost:3000/api/data", {
+        "Sec-Fetch-Dest": "empty",
+      });
+      await withAuth(req);
+      expect(NextResponse.json).toHaveBeenCalledWith(
+        { statusCode: 401, message: "Unauthorized" },
+        { status: 401 },
+      );
+    });
+
+    it("returns HTTP 401 for GET fetch with Sec-Fetch-Mode cors", async () => {
+      const req = makeRequest("GET", "http://localhost:3000/api/data", {
+        "Sec-Fetch-Mode": "cors",
+      });
+      await withAuth(req);
+      expect(NextResponse.json).toHaveBeenCalledWith(
+        { statusCode: 401, message: "Unauthorized" },
+        { status: 401 },
+      );
+    });
+
+    it("returns HTTP 401 for GET when Accept prefers application/json", async () => {
+      const req = makeRequest("GET", "http://localhost:3000/api/data", {
+        Accept: "application/json",
+      });
+      await withAuth(req);
+      expect(NextResponse.json).toHaveBeenCalledWith(
+        { statusCode: 401, message: "Unauthorized" },
+        { status: 401 },
+      );
+    });
+
+    it("redirects document GET navigation (text/html Accept)", async () => {
+      const req = makeRequest("GET", "http://localhost:3000/dashboard", {
+        Accept: "text/html,application/xhtml+xml",
+        "Sec-Fetch-Dest": "document",
+        "Sec-Fetch-Mode": "navigate",
+      });
       await withAuth(req);
       expect(NextResponse.json).not.toHaveBeenCalled();
       expect(NextResponse.redirect).toHaveBeenCalled();

--- a/tests/authMiddleware/authMiddleware.test.ts
+++ b/tests/authMiddleware/authMiddleware.test.ts
@@ -239,5 +239,17 @@ describe("authMiddleware — non-GET/HEAD returns HTTP 401", () => {
       expect(NextResponse.json).not.toHaveBeenCalled();
       expect(NextResponse.redirect).toHaveBeenCalled();
     });
+
+    it("redirects Next.js App Router RSC GET instead of returning 401", async () => {
+      const req = makeRequest("GET", "http://localhost:3000/dashboard", {
+        RSC: "1",
+        "Next-Router-State-Tree": "[]",
+        "Sec-Fetch-Dest": "empty",
+        "Sec-Fetch-Mode": "cors",
+      });
+      await withAuth(req);
+      expect(NextResponse.json).not.toHaveBeenCalled();
+      expect(NextResponse.redirect).toHaveBeenCalled();
+    });
   });
 });

--- a/tests/frontend/LogoutLink.test.tsx
+++ b/tests/frontend/LogoutLink.test.tsx
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import React from "react";
+import { render, fireEvent, cleanup } from "@testing-library/react";
+
+vi.mock("../../src/config/index", () => ({
+  config: {
+    apiPath: "/api/auth",
+  },
+  routes: {
+    logout: "logout",
+  },
+}));
+
+const publishSessionEvent = vi.hoisted(() => vi.fn());
+vi.mock("../../src/frontend/sessionChannel", () => ({
+  publishSessionEvent,
+}));
+
+import { LogoutLink } from "../../src/components/LogoutLink";
+
+describe("LogoutLink", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("publishes logged_out before navigation", () => {
+    const { getByText } = render(
+      React.createElement(LogoutLink, null, "Sign out"),
+    );
+
+    fireEvent.click(getByText("Sign out"));
+
+    expect(publishSessionEvent).toHaveBeenCalledWith({ type: "logged_out" });
+  });
+
+  it("calls consumer onClick after publishing", () => {
+    const onClick = vi.fn();
+    const { getByText } = render(
+      React.createElement(LogoutLink, { onClick }, "Sign out"),
+    );
+
+    fireEvent.click(getByText("Sign out"));
+
+    expect(publishSessionEvent).toHaveBeenCalledWith({ type: "logged_out" });
+    expect(onClick).toHaveBeenCalled();
+  });
+
+  it("includes postLogoutRedirectURL in href", () => {
+    const { getByText } = render(
+      React.createElement(
+        LogoutLink,
+        { postLogoutRedirectURL: "/bye" },
+        "Sign out",
+      ),
+    );
+
+    const anchor = getByText("Sign out").closest("a");
+    expect(anchor?.getAttribute("href")).toBe(
+      "/api/auth/logout?post_logout_redirect_url=/bye",
+    );
+  });
+});

--- a/tests/frontend/sessionChannel.test.ts
+++ b/tests/frontend/sessionChannel.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  KINDE_AUTH_STORAGE_KEY,
+  publishSessionEvent,
+  subscribeSessionEvents,
+} from "../../src/frontend/sessionChannel";
+
+const createMemoryStorage = () => {
+  const store = new Map<string, string>();
+  return {
+    getItem: (key: string) => store.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      store.set(key, value);
+    },
+    removeItem: (key: string) => {
+      store.delete(key);
+    },
+    clear: () => {
+      store.clear();
+    },
+  };
+};
+
+describe("sessionChannel", () => {
+  beforeEach(() => {
+    vi.stubGlobal("localStorage", createMemoryStorage());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("publishSessionEvent posts via BroadcastChannel when available", () => {
+    const postMessage = vi.fn();
+    const close = vi.fn();
+
+    class MockBroadcastChannel {
+      postMessage = postMessage;
+      close = close;
+      onmessage: ((event: MessageEvent) => void) | null = null;
+      constructor(public name: string) {}
+    }
+
+    vi.stubGlobal("BroadcastChannel", MockBroadcastChannel);
+
+    publishSessionEvent({ type: "logged_out" });
+
+    expect(postMessage).toHaveBeenCalledWith({ type: "logged_out" });
+    expect(close).toHaveBeenCalled();
+  });
+
+  it("publishSessionEvent writes localStorage fallback payload", () => {
+    class FailingBroadcastChannel {
+      constructor() {
+        throw new Error("unsupported");
+      }
+    }
+    vi.stubGlobal("BroadcastChannel", FailingBroadcastChannel);
+
+    publishSessionEvent({ type: "logged_out" });
+
+    const raw = localStorage.getItem(KINDE_AUTH_STORAGE_KEY);
+    expect(raw).toBeTruthy();
+    expect(JSON.parse(raw!)).toMatchObject({ type: "logged_out" });
+  });
+
+  it("subscribeSessionEvents invokes handler on BroadcastChannel message", () => {
+    const instances: Array<{
+      onmessage: ((event: MessageEvent) => void) | null;
+    }> = [];
+
+    class MockBroadcastChannel {
+      onmessage: ((event: MessageEvent) => void) | null = null;
+      postMessage = vi.fn();
+      close = vi.fn();
+      constructor(public name: string) {
+        instances.push(this);
+      }
+    }
+
+    vi.stubGlobal("BroadcastChannel", MockBroadcastChannel);
+
+    const handler = vi.fn();
+    const unsubscribe = subscribeSessionEvents(handler);
+
+    instances[0]?.onmessage?.({
+      data: { type: "logged_out" },
+    } as MessageEvent);
+    expect(handler).toHaveBeenCalledWith({ type: "logged_out" });
+
+    unsubscribe();
+  });
+
+  it("subscribeSessionEvents invokes handler on storage events", () => {
+    class FailingBroadcastChannel {
+      constructor() {
+        throw new Error("unsupported");
+      }
+    }
+    vi.stubGlobal("BroadcastChannel", FailingBroadcastChannel);
+
+    const handler = vi.fn();
+    const unsubscribe = subscribeSessionEvents(handler);
+
+    window.dispatchEvent(
+      new StorageEvent("storage", {
+        key: KINDE_AUTH_STORAGE_KEY,
+        newValue: JSON.stringify({ type: "logged_out", ts: Date.now() }),
+      }),
+    );
+
+    expect(handler).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "logged_out" }),
+    );
+
+    unsubscribe();
+  });
+});

--- a/tests/frontend/useSessionSync.test.ts
+++ b/tests/frontend/useSessionSync.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+
+const fetchKindeState = vi.hoisted(() => vi.fn());
+const destroySession = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+const setItems = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+const setRefreshTimer = vi.hoisted(() => vi.fn());
+const clearRefreshTimer = vi.hoisted(() => vi.fn());
+const getDecodedToken = vi.hoisted(() => vi.fn());
+const sessionHandlerRef = vi.hoisted(() => ({
+  current: null as null | ((event: { type: string }) => void | Promise<void>),
+}));
+
+vi.mock("../../src/frontend/utils", () => ({
+  fetchKindeState,
+}));
+
+vi.mock("../../src/frontend/store", () => ({
+  clientStorage: {
+    destroySession,
+    setItems,
+  },
+}));
+
+vi.mock("../../src/config/index", () => ({
+  config: { isDebugMode: false },
+}));
+
+vi.mock("@kinde-oss/kinde-auth-react/utils", () => ({
+  StorageKeys: {
+    accessToken: "accessToken",
+    idToken: "idToken",
+  },
+  setRefreshTimer,
+  clearRefreshTimer,
+  getDecodedToken,
+}));
+
+vi.mock("../../src/frontend/sessionChannel", () => ({
+  subscribeSessionEvents: (
+    handler: (event: { type: string }) => void | Promise<void>,
+  ) => {
+    sessionHandlerRef.current = handler;
+    return () => {
+      sessionHandlerRef.current = null;
+    };
+  },
+}));
+
+import { useSessionSync } from "../../src/frontend/hooks/internal/use-session-sync";
+
+const ENV = {
+  clientId: "client_123",
+  issuerUrl: "https://example.kinde.com",
+  redirectUrl: "http://localhost:3000",
+};
+
+const loggedInState = {
+  accessToken: { sub: "user_1" },
+  accessTokenEncoded: "access.jwt",
+  idToken: { sub: "user_1" },
+  idTokenRaw: "id.jwt",
+  featureFlags: {},
+  organization: null,
+  permissions: null,
+  user: { id: "user_1" },
+  userOrganizations: null,
+  isAuthenticated: true,
+};
+
+describe("useSessionSync — cross-tab and focus sync", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    sessionHandlerRef.current = null;
+    destroySession.mockResolvedValue(undefined);
+    setItems.mockResolvedValue(undefined);
+    getDecodedToken.mockResolvedValue({
+      exp: Math.floor(Date.now() / 1000) + 3600,
+    });
+    fetchKindeState.mockResolvedValue({
+      success: true,
+      kindeState: loggedInState,
+      env: ENV,
+    });
+  });
+
+  it("clears client session when logged_out is received", async () => {
+    const { result } = renderHook(() => useSessionSync());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(sessionHandlerRef.current).toBeTypeOf("function");
+
+    await act(async () => {
+      await sessionHandlerRef.current?.({ type: "logged_out" });
+    });
+
+    expect(clearRefreshTimer).toHaveBeenCalled();
+    expect(destroySession).toHaveBeenCalled();
+    expect(result.current.getFetchedState().isAuthenticated).toBe(false);
+    expect(result.current.getFetchedState().error).toBeNull();
+  });
+
+  it("revalidates via setup on visibilitychange to visible", async () => {
+    const { result } = renderHook(() => useSessionSync());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    const initialCalls = fetchKindeState.mock.calls.length;
+
+    fetchKindeState.mockResolvedValue({
+      success: false,
+      error: "Not logged in",
+      env: ENV,
+    });
+
+    await act(async () => {
+      Object.defineProperty(document, "visibilityState", {
+        configurable: true,
+        get: () => "visible",
+      });
+      document.dispatchEvent(new Event("visibilitychange"));
+      // Allow the async visibility handler to settle.
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(fetchKindeState.mock.calls.length).toBeGreaterThan(initialCalls);
+      expect(result.current.getFetchedState().isAuthenticated).toBe(false);
+    });
+
+    expect(destroySession).toHaveBeenCalled();
+  });
+
+  it("updates tokens when focus revalidate succeeds", async () => {
+    const { result } = renderHook(() => useSessionSync());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    fetchKindeState.mockResolvedValue({
+      success: true,
+      kindeState: {
+        ...loggedInState,
+        accessTokenEncoded: "access.jwt.refreshed",
+        idTokenRaw: "id.jwt.refreshed",
+      },
+      env: ENV,
+    });
+
+    await act(async () => {
+      Object.defineProperty(document, "visibilityState", {
+        configurable: true,
+        get: () => "visible",
+      });
+      document.dispatchEvent(new Event("visibilitychange"));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(result.current.getFetchedState().accessTokenEncoded).toBe(
+        "access.jwt.refreshed",
+      );
+    });
+
+    expect(setItems).toHaveBeenCalled();
+  });
+});

--- a/tests/frontend/useSessionSync.test.ts
+++ b/tests/frontend/useSessionSync.test.ts
@@ -103,6 +103,56 @@ describe("useSessionSync — cross-tab and focus sync", () => {
     expect(result.current.getFetchedState().error).toBeNull();
   });
 
+  it("does not restore stale state when logged_out arrives during setup", async () => {
+    let resolveSetup: (value: unknown) => void = () => {};
+    const pendingSetup = new Promise((resolve) => {
+      resolveSetup = resolve;
+    });
+
+    fetchKindeState.mockReturnValueOnce(
+      Promise.resolve({
+        success: true,
+        kindeState: loggedInState,
+        env: ENV,
+      }),
+    );
+
+    const { result } = renderHook(() => useSessionSync());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    fetchKindeState.mockReturnValueOnce(pendingSetup);
+
+    await act(async () => {
+      void result.current.refetch();
+    });
+
+    await act(async () => {
+      await sessionHandlerRef.current?.({ type: "logged_out" });
+    });
+
+    expect(result.current.getFetchedState().isAuthenticated).toBe(false);
+
+    await act(async () => {
+      resolveSetup({
+        success: true,
+        kindeState: {
+          ...loggedInState,
+          accessTokenEncoded: "stale.access.jwt",
+          idTokenRaw: "stale.id.jwt",
+        },
+        env: ENV,
+      });
+      await pendingSetup;
+      await Promise.resolve();
+    });
+
+    expect(result.current.getFetchedState().isAuthenticated).toBe(false);
+    expect(result.current.getFetchedState().accessTokenEncoded).toBeNull();
+  });
+
   it("revalidates via setup on visibilitychange to visible", async () => {
     const { result } = renderHook(() => useSessionSync());
 

--- a/tests/frontend/useSessionSync.test.ts
+++ b/tests/frontend/useSessionSync.test.ts
@@ -153,6 +153,80 @@ describe("useSessionSync — cross-tab and focus sync", () => {
     expect(result.current.getFetchedState().accessTokenEncoded).toBeNull();
   });
 
+  it("settles initial loading when logged_out arrives during the first setup", async () => {
+    let resolveSetup: (value: unknown) => void = () => {};
+    const pendingSetup = new Promise((resolve) => {
+      resolveSetup = resolve;
+    });
+
+    fetchKindeState.mockReturnValueOnce(pendingSetup);
+
+    const { result } = renderHook(() => useSessionSync());
+
+    await act(async () => {
+      await sessionHandlerRef.current?.({ type: "logged_out" });
+    });
+
+    await act(async () => {
+      resolveSetup({
+        success: true,
+        kindeState: loggedInState,
+        env: ENV,
+      });
+      await pendingSetup;
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.config).toEqual(ENV);
+    expect(result.current.getFetchedState().isAuthenticated).toBe(false);
+  });
+
+  it("does not restore stale state when logged_out arrives during refresh", async () => {
+    const { result } = renderHook(() => useSessionSync());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    let resolveRefresh: (value: unknown) => void = () => {};
+    const pendingRefresh = new Promise((resolve) => {
+      resolveRefresh = resolve;
+    });
+
+    fetchKindeState.mockReturnValueOnce(pendingRefresh);
+
+    let refreshPromise: Promise<unknown> = Promise.resolve();
+    await act(async () => {
+      refreshPromise = result.current.refreshHandler();
+    });
+
+    await act(async () => {
+      await sessionHandlerRef.current?.({ type: "logged_out" });
+    });
+
+    let refreshResult: unknown;
+    await act(async () => {
+      resolveRefresh({
+        success: true,
+        kindeState: {
+          ...loggedInState,
+          accessTokenEncoded: "stale.access.jwt",
+          idTokenRaw: "stale.id.jwt",
+        },
+        env: ENV,
+      });
+      refreshResult = await refreshPromise;
+    });
+
+    expect(refreshResult).toMatchObject({ success: false });
+    expect(result.current.getFetchedState().isAuthenticated).toBe(false);
+    expect(result.current.getFetchedState().accessTokenEncoded).toBeNull();
+  });
+
   it("revalidates via setup on visibilitychange to visible", async () => {
     const { result } = renderHook(() => useSessionSync());
 

--- a/tests/frontend/useSessionSync.test.ts
+++ b/tests/frontend/useSessionSync.test.ts
@@ -153,6 +153,55 @@ describe("useSessionSync — cross-tab and focus sync", () => {
     expect(result.current.getFetchedState().accessTokenEncoded).toBeNull();
   });
 
+  it("does not restore stale state when logged_out arrives while tokens are being written", async () => {
+    const { result } = renderHook(() => useSessionSync());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    let resolveSetItems: (value: unknown) => void = () => {};
+    const pendingSetItems = new Promise((resolve) => {
+      resolveSetItems = resolve;
+    });
+    setItems.mockReturnValueOnce(pendingSetItems);
+
+    fetchKindeState.mockResolvedValueOnce({
+      success: true,
+      kindeState: {
+        ...loggedInState,
+        accessTokenEncoded: "stale.access.jwt",
+        idTokenRaw: "stale.id.jwt",
+      },
+      env: ENV,
+    });
+
+    await act(async () => {
+      void result.current.refetch();
+    });
+
+    await waitFor(() => {
+      expect(setItems).toHaveBeenCalled();
+    });
+
+    await act(async () => {
+      await sessionHandlerRef.current?.({ type: "logged_out" });
+    });
+
+    expect(result.current.getFetchedState().isAuthenticated).toBe(false);
+
+    await act(async () => {
+      resolveSetItems(undefined);
+      await pendingSetItems;
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(result.current.getFetchedState().isAuthenticated).toBe(false);
+    expect(result.current.getFetchedState().accessTokenEncoded).toBeNull();
+    expect(destroySession).toHaveBeenCalled();
+  });
+
   it("settles initial loading when logged_out arrives during the first setup", async () => {
     let resolveSetup: (value: unknown) => void = () => {};
     const pendingSetup = new Promise((resolve) => {

--- a/tests/frontend/useSessionSync.test.ts
+++ b/tests/frontend/useSessionSync.test.ts
@@ -69,6 +69,16 @@ const loggedInState = {
 };
 
 describe("useSessionSync — cross-tab and focus sync", () => {
+  const setDocumentVisible = async () => {
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      get: () => "visible",
+    });
+    document.dispatchEvent(new Event("visibilitychange"));
+    await Promise.resolve();
+    await Promise.resolve();
+  };
+
   beforeEach(() => {
     vi.clearAllMocks();
     sessionHandlerRef.current = null;
@@ -276,6 +286,91 @@ describe("useSessionSync — cross-tab and focus sync", () => {
     expect(result.current.getFetchedState().accessTokenEncoded).toBeNull();
   });
 
+  it("does not restore session on focus while cookies are still valid after logged_out", async () => {
+    const { result } = renderHook(() => useSessionSync());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    await act(async () => {
+      await sessionHandlerRef.current?.({ type: "logged_out" });
+    });
+
+    expect(result.current.getFetchedState().isAuthenticated).toBe(false);
+
+    const setItemsAfterLogout = setItems.mock.calls.length;
+    fetchKindeState.mockResolvedValue({
+      success: true,
+      kindeState: {
+        ...loggedInState,
+        accessTokenEncoded: "access.jwt.still-valid-cookies",
+        idTokenRaw: "id.jwt.still-valid-cookies",
+      },
+      env: ENV,
+    });
+
+    await act(async () => {
+      await setDocumentVisible();
+    });
+
+    await waitFor(() => {
+      expect(fetchKindeState.mock.calls.length).toBeGreaterThan(1);
+    });
+
+    expect(result.current.getFetchedState().isAuthenticated).toBe(false);
+    expect(result.current.getFetchedState().accessTokenEncoded).toBeNull();
+    expect(setItems.mock.calls.length).toBe(setItemsAfterLogout);
+  });
+
+  it("allows cookie revalidation again after /setup reports logged out", async () => {
+    const { result } = renderHook(() => useSessionSync());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    await act(async () => {
+      await sessionHandlerRef.current?.({ type: "logged_out" });
+    });
+
+    fetchKindeState.mockResolvedValue({
+      success: false,
+      error: "Not logged in",
+      env: ENV,
+    });
+
+    await act(async () => {
+      await setDocumentVisible();
+    });
+
+    await waitFor(() => {
+      expect(result.current.getFetchedState().isAuthenticated).toBe(false);
+    });
+
+    fetchKindeState.mockResolvedValue({
+      success: true,
+      kindeState: {
+        ...loggedInState,
+        accessTokenEncoded: "access.jwt.relogin",
+        idTokenRaw: "id.jwt.relogin",
+      },
+      env: ENV,
+    });
+
+    await act(async () => {
+      await setDocumentVisible();
+    });
+
+    await waitFor(() => {
+      expect(result.current.getFetchedState().accessTokenEncoded).toBe(
+        "access.jwt.relogin",
+      );
+    });
+
+    expect(result.current.getFetchedState().isAuthenticated).toBe(true);
+  });
+
   it("revalidates via setup on visibilitychange to visible", async () => {
     const { result } = renderHook(() => useSessionSync());
 
@@ -292,14 +387,7 @@ describe("useSessionSync — cross-tab and focus sync", () => {
     });
 
     await act(async () => {
-      Object.defineProperty(document, "visibilityState", {
-        configurable: true,
-        get: () => "visible",
-      });
-      document.dispatchEvent(new Event("visibilitychange"));
-      // Allow the async visibility handler to settle.
-      await Promise.resolve();
-      await Promise.resolve();
+      await setDocumentVisible();
     });
 
     await waitFor(() => {
@@ -328,13 +416,7 @@ describe("useSessionSync — cross-tab and focus sync", () => {
     });
 
     await act(async () => {
-      Object.defineProperty(document, "visibilityState", {
-        configurable: true,
-        get: () => "visible",
-      });
-      document.dispatchEvent(new Event("visibilitychange"));
-      await Promise.resolve();
-      await Promise.resolve();
+      await setDocumentVisible();
     });
 
     await waitFor(() => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
+import react from "@vitejs/plugin-react";
 
 export default defineConfig({
+  // Vitest ignores vite.config.mts, so the automatic JSX runtime has to be
+  // enabled here too or .jsx components compile to React.createElement.
+  plugins: [react()],
   test: {
     environment: "happy-dom",
   },


### PR DESCRIPTION

# Explain your changes

Allow for better multi-tab support to prevent a cors 5xx error from firing when a user logs out, switches tabs, then attempts to refresh data. 

Error thrown should be a 401, to allow better API integration. 

_Suppose there is a related issue with enough detail for a reviewer to understand your changes fully. In that case, you can omit an explanation and instead include either “Fixes #XX” or “Updates #XX” where “XX” is the issue number._

# Checklist

- [X] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [X] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
