### PR TITLE
fix: remove redirectOnExpiredToken from isAuthenticated to fix expected behavior (#337)

### DIFF
--- a/src/session/isAuthenticated.js
+++ b/src/session/isAuthenticated.js
@@ -1,11 +1,11 @@
 import { getUserFactory } from "./getUser";
 import { getAccessToken } from "../utils/getAccessToken";
-import { isTokenExpired } from "../utils/jwt/validation";
-import { redirect } from "next/navigation";
-import { redirectOnExpiredToken } from "../utils/redirectOnExpiredToken";
 import { config } from "../config/index";
 
 /**
+ * Returns a function that checks if the user is authenticated.
+ * This function simply returns true/false based on token validity,
+ * without triggering redirects. Use middleware for route protection.
  *
  * @param {import('next').NextApiRequest} [req]
  * @param {import('next').NextApiResponse} [res]
@@ -13,10 +13,6 @@ import { config } from "../config/index";
  */
 export const isAuthenticatedFactory = (req, res) => async () => {
   const token = await getAccessToken(req, res);
-  if (config.isDebugMode) {
-    console.log("isAuthenticatedFactory: running redirectOnExpiredToken check");
-  }
-  redirectOnExpiredToken(token);
   const user = await getUserFactory(req, res)();
   return token && Boolean(user);
 };


### PR DESCRIPTION
This PR fixes issue #337 where `isAuthenticated()` was triggering a redirect instead of simply returning true/false based on token validity.

**Changes:**
- Removed the `redirectOnExpiredToken` call from `isAuthenticated()` in `src/session/isAuthenticated.js`
- This restores the v2.4.6 behavior where the function returned `false` for expired tokens instead of redirecting

**Rationale:**
- `isAuthenticated()` should simply check token validity and return a boolean
- Route protection and redirects should be handled by middleware
- This matches the documented behavior in the Kinde docs

**Fixes:** #337