### PR TITLE
fix: allowlist params forwarded to the Kinde authorize URL

### DIFF
--- a/src/handlers/callback.ts
+++ b/src/handlers/callback.ts
@@ -1,5 +1,6 @@
 import { config, routes } from "../config/index";
 import RouterClient from "../routerClients/RouterClient";
+import { filterAuthUrlParams } from "../utils/filterAuthUrlParams";
 
 const redirectToLogin = (routerClient: RouterClient) => {
   const loginUrl = new URL(
@@ -22,7 +23,9 @@ export const callback = async (routerClient: RouterClient) => {
           const decodedAuthState = atob(reauthState);
           const parsedReauthState = JSON.parse(decodedAuthState);
           if (parsedReauthState) {
-            const urlParams = new URLSearchParams(parsedReauthState);
+            const urlParams = new URLSearchParams(
+              filterAuthUrlParams(parsedReauthState),
+            );
             const loginRoute = new URL(
               `${config.redirectURL}${config.apiPath}/${routes.login}`,
             );

--- a/src/handlers/login.ts
+++ b/src/handlers/login.ts
@@ -3,6 +3,7 @@ import { isPreFetch } from "../utils/isPreFetch";
 import { getHeaders } from "../utils/getHeaders";
 import validateState from "../utils/validateState";
 import { config } from "../config/index";
+import { filterAuthUrlParams } from "../utils/filterAuthUrlParams";
 
 /**
  *
@@ -28,7 +29,7 @@ export const login = async (routerClient: RouterClient) => {
     routerClient.sessionManager,
     {
       authUrlParams: {
-        ...Object.fromEntries(routerClient.searchParams),
+        ...filterAuthUrlParams(routerClient.searchParams),
         supports_reauth: "true",
       },
     },

--- a/src/handlers/register.ts
+++ b/src/handlers/register.ts
@@ -3,6 +3,7 @@ import { getHeaders } from "../utils/getHeaders";
 import { isPreFetch } from "../utils/isPreFetch";
 import validateState from "../utils/validateState";
 import { config } from "../config/index";
+import { filterAuthUrlParams } from "../utils/filterAuthUrlParams";
 
 /**
  *
@@ -18,7 +19,7 @@ export const register = async (routerClient: RouterClient) => {
     routerClient.sessionManager,
     {
       authUrlParams: {
-        ...Object.fromEntries(routerClient.searchParams),
+        ...filterAuthUrlParams(routerClient.searchParams),
         supports_reauth: "true",
       },
     },

--- a/src/utils/filterAuthUrlParams.test.ts
+++ b/src/utils/filterAuthUrlParams.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import { filterAuthUrlParams } from "./filterAuthUrlParams";
+
+describe("filterAuthUrlParams", () => {
+  it("keeps documented Kinde application parameters", () => {
+    const params = new URLSearchParams({
+      org_code: "org_123",
+      login_hint: "user@example.com",
+      connection_id: "conn_abc",
+      lang: "en-AU",
+      utm_source: "docs",
+    });
+
+    expect(filterAuthUrlParams(params)).toEqual({
+      org_code: "org_123",
+      login_hint: "user@example.com",
+      connection_id: "conn_abc",
+      lang: "en-AU",
+      utm_source: "docs",
+    });
+  });
+
+  it("drops OAuth protocol parameters", () => {
+    const params = new URLSearchParams({
+      org_code: "org_123",
+      code_challenge: "attacker",
+      code_challenge_method: "plain",
+      response_mode: "fragment",
+      prompt: "none",
+      redirect_uri: "https://evil.example/callback",
+      client_id: "spoofed",
+      response_type: "token",
+      scope: "admin",
+      audience: "https://evil.example",
+      client_secret: "secret",
+    });
+
+    expect(filterAuthUrlParams(params)).toEqual({
+      org_code: "org_123",
+    });
+  });
+
+  it("drops empty values and non-scalar JSON fields", () => {
+    expect(
+      filterAuthUrlParams({
+        org_code: "org_123",
+        login_hint: "",
+        nested: { code_challenge: "attacker" },
+      }),
+    ).toEqual({ org_code: "org_123" });
+  });
+
+  it("returns an empty object for null, arrays, and missing input", () => {
+    expect(filterAuthUrlParams(null)).toEqual({});
+    expect(filterAuthUrlParams(undefined)).toEqual({});
+    expect(filterAuthUrlParams([])).toEqual({});
+  });
+});

--- a/src/utils/filterAuthUrlParams.ts
+++ b/src/utils/filterAuthUrlParams.ts
@@ -1,0 +1,71 @@
+/**
+ * Kinde application parameters that login/register are allowed to copy from
+ * the incoming request onto the authorization URL.
+ *
+ * Protocol parameters (code_challenge, response_mode, prompt, redirect_uri,
+ * client_id, …) are owned by the SDK / authorization server and must not be
+ * taken from attacker-controlled query strings.
+ */
+export const ALLOWED_AUTH_URL_PARAMS = [
+  "org_code",
+  "org_name",
+  "is_create_org",
+  "login_hint",
+  "connection_id",
+  "lang",
+  "start_page",
+  "invitation_code",
+  "is_invitation",
+  "has_success_page",
+  "workflow_deployment_id",
+  "supports_reauth",
+  "plan_interest",
+  "pricing_table_key",
+  "pages_mode",
+  "utm_source",
+  "utm_medium",
+  "utm_campaign",
+  "utm_term",
+  "utm_content",
+] as const;
+
+const allowedAuthUrlParams = new Set<string>(ALLOWED_AUTH_URL_PARAMS);
+
+const isScalarParamValue = (
+  value: unknown,
+): value is string | number | boolean =>
+  typeof value === "string" ||
+  typeof value === "number" ||
+  typeof value === "boolean";
+
+/**
+ * Return only allowlisted authorization parameters from a query string or
+ * parsed object (e.g. decoded reauth_state).
+ */
+export function filterAuthUrlParams(params: unknown): Record<string, string> {
+  if (params == null) {
+    return {};
+  }
+
+  let entries: [string, unknown][];
+  if (params instanceof URLSearchParams) {
+    entries = Array.from(params.entries());
+  } else if (typeof params === "object" && !Array.isArray(params)) {
+    entries = Object.entries(params);
+  } else {
+    return {};
+  }
+
+  const filtered: Record<string, string> = {};
+  for (const [key, value] of entries) {
+    if (!allowedAuthUrlParams.has(key) || !isScalarParamValue(value)) {
+      continue;
+    }
+    const stringValue = String(value);
+    if (stringValue === "") {
+      continue;
+    }
+    filtered[key] = stringValue;
+  }
+  return filtered;
+}

--- a/tests/handlers/authUrlParams.test.ts
+++ b/tests/handlers/authUrlParams.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../../src/utils/getHeaders", () => ({
+  getHeaders: vi.fn(),
+}));
+
+vi.mock("../../src/utils/isPreFetch", () => ({
+  isPreFetch: vi.fn(),
+}));
+
+vi.mock("../../src/config/index", () => ({
+  config: {
+    postLoginRedirectURL: undefined,
+  },
+}));
+
+import { login } from "../../src/handlers/login";
+import { register } from "../../src/handlers/register";
+import { getHeaders } from "../../src/utils/getHeaders";
+import { isPreFetch } from "../../src/utils/isPreFetch";
+
+const mockGetHeaders = vi.mocked(getHeaders);
+const mockIsPreFetch = vi.mocked(isPreFetch);
+
+const createRouterClient = (search: string) => {
+  const searchParams = new URLSearchParams(search);
+  return {
+    req: {},
+    noContent: vi.fn(),
+    searchParams,
+    getSearchParam: (key: string) => searchParams.get(key),
+    sessionManager: { setSessionItem: vi.fn() },
+    kindeClient: {
+      login: vi
+        .fn()
+        .mockResolvedValue(new URL("https://example.kinde.com/oauth2/auth")),
+      register: vi
+        .fn()
+        .mockResolvedValue(new URL("https://example.kinde.com/oauth2/auth")),
+    },
+    redirect: vi.fn((url: string) => url),
+  };
+};
+
+describe("login and register — auth URL param allowlist", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetHeaders.mockResolvedValue(new Headers());
+    mockIsPreFetch.mockReturnValue(false);
+  });
+
+  it("forwards allowlisted params and drops protocol params on login", async () => {
+    const routerClient = createRouterClient(
+      "org_code=org_123&login_hint=user@example.com&code_challenge=attacker&code_challenge_method=plain&response_mode=fragment&prompt=none",
+    );
+
+    await login(routerClient as never);
+
+    expect(routerClient.kindeClient.login).toHaveBeenCalledWith(
+      routerClient.sessionManager,
+      {
+        authUrlParams: {
+          org_code: "org_123",
+          login_hint: "user@example.com",
+          supports_reauth: "true",
+        },
+      },
+    );
+  });
+
+  it("forwards allowlisted params and drops protocol params on register", async () => {
+    const routerClient = createRouterClient(
+      "org_code=org_123&code_challenge=attacker&response_mode=fragment",
+    );
+
+    await register(routerClient as never);
+
+    expect(routerClient.kindeClient.register).toHaveBeenCalledWith(
+      routerClient.sessionManager,
+      {
+        authUrlParams: {
+          org_code: "org_123",
+          supports_reauth: "true",
+        },
+      },
+    );
+  });
+});

--- a/tests/handlers/callback.reauthState.test.ts
+++ b/tests/handlers/callback.reauthState.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../../src/config/index", () => ({
+  config: {
+    redirectURL: "https://app.example",
+    apiPath: "/api/auth",
+    postLoginRedirectURL: undefined,
+    postLoginAllowedURLRegex: undefined,
+    isDebugMode: false,
+  },
+  routes: {
+    login: "login",
+  },
+}));
+
+import { callback } from "../../src/handlers/callback";
+
+const createRouterClient = (search: string) => {
+  const searchParams = new URLSearchParams(search);
+  return {
+    req: {},
+    searchParams,
+    getSearchParam: (key: string) => searchParams.get(key),
+    sessionManager: {
+      getSessionItem: vi.fn(),
+      setSessionItem: vi.fn(),
+      removeSessionItem: vi.fn(),
+    },
+    kindeClient: {
+      handleRedirectToApp: vi.fn(),
+    },
+    getUrl: vi.fn(),
+    clientConfig: { siteUrl: "https://app.example" },
+    json: vi.fn(),
+    redirect: vi.fn((url: string) => url),
+  };
+};
+
+describe("callback — reauth_state allowlist", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("forwards only allowlisted fields from unsigned reauth_state", async () => {
+    const reauthState = btoa(
+      JSON.stringify({
+        org_code: "org_123",
+        client_id: "spoofed_client",
+        code_challenge: "attacker",
+        response_mode: "fragment",
+        prompt: "none",
+      }),
+    );
+    const routerClient = createRouterClient(
+      `error=login_link_expired&reauth_state=${encodeURIComponent(reauthState)}`,
+    );
+
+    const result = await callback(routerClient as never);
+
+    expect(routerClient.redirect).toHaveBeenCalledOnce();
+    const redirected = new URL(String(result));
+    expect(redirected.pathname).toBe("/api/auth/login");
+    expect(redirected.searchParams.get("org_code")).toBe("org_123");
+    expect(redirected.searchParams.get("client_id")).toBeNull();
+    expect(redirected.searchParams.get("code_challenge")).toBeNull();
+    expect(redirected.searchParams.get("response_mode")).toBeNull();
+    expect(redirected.searchParams.get("prompt")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- Stop login/register from copying every incoming query parameter onto the Kinde authorization URL.
- Allow only documented application params (`org_code`, `login_hint`, `connection_id`, UTMs, etc.) and drop protocol params such as `code_challenge`, `response_mode`, `prompt`, `redirect_uri`, and `client_id`.
- Apply the same filter when expanding unsigned `reauth_state` in the callback so extra JSON fields cannot be replayed onto `/login`.

## Test plan
- [ ] `pnpm exec vitest run`
- [ ] Confirm `/api/auth/login?org_code=org_123&login_hint=user@example.com` still reaches Kinde with those params
- [ ] Confirm `/api/auth/login?code_challenge=test&code_challenge_method=plain&response_mode=fragment&prompt=none` does **not** put those params on the authorize `Location`
- [ ] Confirm `LoginLink` / `RegisterLink` `authUrlParams` for `connection_id`, `lang`, and UTMs still work
- [ ] Confirm expired-link reauth still restores `org_code` and does not forward extra `reauth_state` fields


Made with [Cursor](https://cursor.com)